### PR TITLE
fix: add DATABASE_URL to .env.example for ferrox-cp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,14 +25,18 @@ PROXY_KEY_TOKENBANK=sk-proxy-dev-key
 PROXY_KEY_APP=sk-proxy-app-key
 
 # ── Ferrox control plane (ferrox-cp) ─────────────────────────────────────────
+# PostgreSQL connection string for ferrox-cp
+# Docker Compose: postgres://ferrox:ferrox@localhost:5432/ferrox_cp
+# Local Postgres:  postgres://postgres:testpass@localhost:5432/ferrox_cp
+DATABASE_URL=postgres://ferrox:ferrox@localhost:5432/ferrox_cp
+# PostgreSQL password for the ferrox_cp database (used by docker-compose)
+POSTGRES_PASSWORD=ferrox
 # Generate with: openssl rand -hex 32
 CP_ENCRYPTION_KEY=
 # Minimum 32 characters; use a strong random value in production
 CP_ADMIN_KEY=
 # Issuer claim embedded in issued JWTs; must match gateway trusted_issuers config
 CP_ISSUER=http://localhost:9090
-# PostgreSQL password for the ferrox_cp database
-POSTGRES_PASSWORD=ferrox
 
 # ── Telemetry ─────────────────────────────────────────────────────────────────
 LOG_LEVEL=info


### PR DESCRIPTION
\`ferrox-cp\` requires \`DATABASE_URL\` at startup but it was absent from \`.env.example\`. Anyone who ran \`cp .env.example .env && cargo run -p ferrox-cp\` got an immediate startup error.

Also reorders the control-plane block so \`POSTGRES_PASSWORD\` (used by docker-compose to create the DB) sits next to \`DATABASE_URL\` (used by ferrox-cp to connect), making the relationship obvious.