### PR TITLE
fix: auto-generate CP_ENCRYPTION_KEY and CP_ADMIN_KEY via make setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,9 +31,11 @@ PROXY_KEY_APP=sk-proxy-app-key
 DATABASE_URL=postgres://ferrox:ferrox@localhost:5432/ferrox_cp
 # PostgreSQL password for the ferrox_cp database (used by docker-compose)
 POSTGRES_PASSWORD=ferrox
-# Generate with: openssl rand -hex 32
+# AES-256-GCM key for private keys at rest — REQUIRED, must be exactly 64 hex chars.
+# Run: openssl rand -hex 32
 CP_ENCRYPTION_KEY=
-# Minimum 32 characters; use a strong random value in production
+# Static bearer token for the admin REST API and UI — REQUIRED, min 32 chars.
+# Run: openssl rand -hex 20
 CP_ADMIN_KEY=
 # Issuer claim embedded in issued JWTs; must match gateway trusted_issuers config
 CP_ISSUER=http://localhost:9090

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build build-release test fmt lint check run run-release clean \
         docker-build docker-up docker-down docker-logs \
         ui-install ui-build ui-dev \
-        help
+        setup help
 
 # ── Build ──────────────────────────────────────────────────────────────────────
 
@@ -29,6 +29,24 @@ lint:
 check: fmt-check lint test
 
 # ── Run locally ────────────────────────────────────────────────────────────────
+
+## First-time setup: copy .env.example → .env and generate required secrets.
+## Safe to re-run — skips if .env already exists.
+setup:
+	@if [ -f .env ]; then \
+		echo ".env already exists, skipping."; \
+	else \
+		cp .env.example .env; \
+		ENC_KEY=$$(openssl rand -hex 32); \
+		ADMIN_KEY=$$(openssl rand -hex 20); \
+		sed -i "s|^CP_ENCRYPTION_KEY=$$|CP_ENCRYPTION_KEY=$$ENC_KEY|" .env; \
+		sed -i "s|^CP_ADMIN_KEY=$$|CP_ADMIN_KEY=$$ADMIN_KEY|" .env; \
+		echo "Created .env — fill in at least one provider API key before running."; \
+		echo ""; \
+		echo "  CP_ENCRYPTION_KEY  auto-generated ✓"; \
+		echo "  CP_ADMIN_KEY       auto-generated ✓"; \
+		echo "  ANTHROPIC_API_KEY  edit .env and set this"; \
+	fi
 
 ## Copy minimal config template if local config does not exist yet
 ferrox/config/local.yaml:
@@ -102,6 +120,8 @@ clean:
 help:
 	@echo ""
 	@echo "Usage: make <target>"
+	@echo ""
+	@echo "  setup              First-time setup: create .env with generated secrets"
 	@echo ""
 	@echo "  build              Debug build (all workspace members)"
 	@echo "  build-release      Release build (all workspace members)"

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -21,12 +21,12 @@ The runtime image runs as a non-root user.
 # Clone the repo if you haven't already
 git clone https://github.com/shaharia-lab/ferrox && cd ferrox
 
-# Copy minimal config — Compose reads config/config.yaml by default
-cp config/config_minimal.yaml config/config.yaml   # or edit config/config.yaml directly
+# Generate .env with required secrets pre-filled
+make setup
+# Edit .env — set at least one provider key (ANTHROPIC_API_KEY etc.)
 
-# Set your provider API keys
-cp .env.example .env
-# Edit .env and fill in at least one provider key
+# Copy minimal config — Compose reads config/config.yaml by default
+cp ferrox/config/config_minimal.yaml ferrox/config/config.yaml
 
 # Start the full stack
 docker compose up

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -75,8 +75,9 @@ docker run -p 8080:8080 \
 
 ```bash
 git clone https://github.com/shaharia-lab/ferrox && cd ferrox
-cp config/config_minimal.yaml config/local.yaml
-# Set your keys in .env (cp .env.example .env)
+make setup                             # creates .env with generated secrets
+# Edit .env — set at least one provider key (ANTHROPIC_API_KEY etc.)
+cp ferrox/config/config_minimal.yaml ferrox/config/config.yaml
 docker compose up
 ```
 
@@ -119,19 +120,24 @@ curl -Lo local.yaml https://raw.githubusercontent.com/shaharia-lab/ferrox/main/c
 
 ## Set environment variables
 
-**Binary / Homebrew / build from source** — create a `.env` file:
+**Binary / Homebrew / build from source** — run the setup target, which copies
+`.env.example` and auto-generates the required control-plane secrets:
 
 ```bash
-cp .env.example .env
+make setup
 ```
 
-Then set at least one provider key:
+Then open `.env` and set at least one provider key:
 
 ```bash
 # .env
 ANTHROPIC_API_KEY=sk-ant-...
 PROXY_KEY=sk-local-dev       # your inbound virtual key
 ```
+
+`CP_ENCRYPTION_KEY` and `CP_ADMIN_KEY` are filled in automatically by `make setup`.
+If you prefer to set them manually: `CP_ENCRYPTION_KEY` must be exactly 64 hex chars
+(`openssl rand -hex 32`), and `CP_ADMIN_KEY` must be at least 32 chars.
 
 **Docker** — pass keys directly with `-e` flags (see the run command below). Keys for providers you don't use can be omitted — those providers will be skipped.
 


### PR DESCRIPTION
\`CP_ENCRYPTION_KEY\` (must be exactly 64 hex chars) and \`CP_ADMIN_KEY\` are required by \`ferrox-cp\` at startup but were blank in \`.env.example\`, so anyone who ran \`cp .env.example .env && cargo run -p ferrox-cp\` got an immediate config error.

## Changes

- **\`make setup\`** — new Makefile target that copies \`.env.example → .env\` and stamps in \`openssl\`-generated values for both secrets. Safe to re-run (skips if \`.env\` already exists).
- **\`.env.example\`** — improved comments: state that both vars are REQUIRED, document the exact format constraint (64 hex chars), and show the generation command inline.
- **quickstart.md + deployment.md** — replace bare \`cp .env.example .env\` with \`make setup\` so the first-run path works out of the box.