### PR TITLE
fix: use localhost for jwks_uri default when running outside Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,10 @@ CP_ENCRYPTION_KEY=
 CP_ADMIN_KEY=
 # Issuer claim embedded in issued JWTs; must match gateway trusted_issuers config
 CP_ISSUER=http://localhost:9090
+# JWKS URI the gateway uses to fetch public keys for JWT validation.
+# Local (binary/source): http://localhost:9090/.well-known/jwks.json
+# Docker Compose:        http://ferrox-cp:9090/.well-known/jwks.json
+CP_JWKS_URI=http://localhost:9090/.well-known/jwks.json
 
 # ── Telemetry ─────────────────────────────────────────────────────────────────
 LOG_LEVEL=info

--- a/ferrox/config/config_minimal.yaml
+++ b/ferrox/config/config_minimal.yaml
@@ -60,5 +60,6 @@ virtual_keys:
 #
 # trusted_issuers:
 #   - issuer: "${CP_ISSUER:-http://localhost:9090}"
-#     jwks_uri: "http://ferrox-cp:9090/.well-known/jwks.json"
+#     # Local (binary/source): use localhost.  Docker Compose: use http://ferrox-cp:9090/...
+#     jwks_uri: "${CP_JWKS_URI:-http://localhost:9090/.well-known/jwks.json}"
 #     audience: "ferrox"


### PR DESCRIPTION
The committed \`config_minimal.yaml\` had \`jwks_uri: http://ferrox-cp:9090/...\` (Docker internal hostname). When running from source locally the gateway logged:

```
WARN ferrox::jwks: JWKS refresh failed — serving stale if available
  error=error sending request for url (http://ferrox-cp:9090/.well-known/jwks.json)
```

and rejected every JWT with \`401 Invalid token\`, even when the JWT was correctly issued by a running local ferrox-cp.

**Fix:** replace the hardcoded hostname with a \`CP_JWKS_URI\` env var that defaults to \`http://localhost:9090/...\`. Docker Compose users set \`CP_JWKS_URI=http://ferrox-cp:9090/.well-known/jwks.json\` in their \`.env\`; local users get the right default automatically.