### PR TITLE
ci: add checksum: sha256 to upload-rust-binary-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
           bin: ferrox
           manifest-path: ferrox/Cargo.toml
           target: ${{ matrix.target }}
+          checksum: sha256
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload ferrox-cp binary
         uses: taiki-e/upload-rust-binary-action@v1
@@ -64,6 +65,7 @@ jobs:
           bin: ferrox-cp
           manifest-path: ferrox-cp/Cargo.toml
           target: ${{ matrix.target }}
+          checksum: sha256
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # ── Docker image — ferrox (gateway) ──────────────────────────────────────────


### PR DESCRIPTION
## Problem

The `docker` and `docker-cp` jobs in the release workflow download pre-built binaries from the GitHub Release and verify them with `sha256sum`. They expect both a `.tar.gz` tarball and a corresponding `.tar.gz.sha256` sidecar file for each binary.

`taiki-e/upload-rust-binary-action` does **not** upload `.sha256` sidecar files by default, so the Docker jobs immediately hit a 404 when trying to fetch the sidecar.

Evidence from the v0.2.0 run (https://github.com/shaharia-lab/ferrox/actions/runs/23949166933):
```
curl: (22) The requested URL returned error: 404
```

The release only contained `.tar.gz` assets — no `.sha256` sidecars.

## Fix

Add `checksum: sha256` to both `upload-rust-binary-action` steps so the action uploads the `.sha256` sidecar alongside each tarball.

## Test plan

- [x] Merge this PR (squash)
- [x] Delete and re-create the v0.2.0 release tag
- [x] Verify the release workflow `upload-assets` job now produces `.sha256` sidecar files
- [x] Verify the `docker` and `docker-cp` jobs succeed