### PR TITLE
ci: fix sha256 sidecar filename in Docker download steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,16 +109,16 @@ jobs:
           BASE="https://github.com/shaharia-lab/ferrox/releases/download/${VERSION}"
 
           # amd64 — download tarball + sha256 sidecar, verify, extract
-          curl -fsSL "${BASE}/ferrox-x86_64-unknown-linux-gnu.tar.gz"        -o ferrox-x86_64-unknown-linux-gnu.tar.gz
-          curl -fsSL "${BASE}/ferrox-x86_64-unknown-linux-gnu.tar.gz.sha256" -o ferrox-x86_64-unknown-linux-gnu.tar.gz.sha256
-          sha256sum --check ferrox-x86_64-unknown-linux-gnu.tar.gz.sha256
+          curl -fsSL "${BASE}/ferrox-x86_64-unknown-linux-gnu.tar.gz" -o ferrox-x86_64-unknown-linux-gnu.tar.gz
+          curl -fsSL "${BASE}/ferrox-x86_64-unknown-linux-gnu.sha256" -o ferrox-x86_64-unknown-linux-gnu.sha256
+          sha256sum --check ferrox-x86_64-unknown-linux-gnu.sha256
           tar xzf ferrox-x86_64-unknown-linux-gnu.tar.gz
           mv ferrox ferrox-amd64
 
           # arm64 — download tarball + sha256 sidecar, verify, extract
-          curl -fsSL "${BASE}/ferrox-aarch64-unknown-linux-gnu.tar.gz"        -o ferrox-aarch64-unknown-linux-gnu.tar.gz
-          curl -fsSL "${BASE}/ferrox-aarch64-unknown-linux-gnu.tar.gz.sha256" -o ferrox-aarch64-unknown-linux-gnu.tar.gz.sha256
-          sha256sum --check ferrox-aarch64-unknown-linux-gnu.tar.gz.sha256
+          curl -fsSL "${BASE}/ferrox-aarch64-unknown-linux-gnu.tar.gz" -o ferrox-aarch64-unknown-linux-gnu.tar.gz
+          curl -fsSL "${BASE}/ferrox-aarch64-unknown-linux-gnu.sha256" -o ferrox-aarch64-unknown-linux-gnu.sha256
+          sha256sum --check ferrox-aarch64-unknown-linux-gnu.sha256
           tar xzf ferrox-aarch64-unknown-linux-gnu.tar.gz
           mv ferrox ferrox-arm64
 
@@ -179,16 +179,16 @@ jobs:
           BASE="https://github.com/shaharia-lab/ferrox/releases/download/${VERSION}"
 
           # amd64 — download tarball + sha256 sidecar, verify, extract
-          curl -fsSL "${BASE}/ferrox-cp-x86_64-unknown-linux-gnu.tar.gz"        -o ferrox-cp-x86_64-unknown-linux-gnu.tar.gz
-          curl -fsSL "${BASE}/ferrox-cp-x86_64-unknown-linux-gnu.tar.gz.sha256" -o ferrox-cp-x86_64-unknown-linux-gnu.tar.gz.sha256
-          sha256sum --check ferrox-cp-x86_64-unknown-linux-gnu.tar.gz.sha256
+          curl -fsSL "${BASE}/ferrox-cp-x86_64-unknown-linux-gnu.tar.gz" -o ferrox-cp-x86_64-unknown-linux-gnu.tar.gz
+          curl -fsSL "${BASE}/ferrox-cp-x86_64-unknown-linux-gnu.sha256" -o ferrox-cp-x86_64-unknown-linux-gnu.sha256
+          sha256sum --check ferrox-cp-x86_64-unknown-linux-gnu.sha256
           tar xzf ferrox-cp-x86_64-unknown-linux-gnu.tar.gz
           mv ferrox-cp ferrox-cp-amd64
 
           # arm64 — download tarball + sha256 sidecar, verify, extract
-          curl -fsSL "${BASE}/ferrox-cp-aarch64-unknown-linux-gnu.tar.gz"        -o ferrox-cp-aarch64-unknown-linux-gnu.tar.gz
-          curl -fsSL "${BASE}/ferrox-cp-aarch64-unknown-linux-gnu.tar.gz.sha256" -o ferrox-cp-aarch64-unknown-linux-gnu.tar.gz.sha256
-          sha256sum --check ferrox-cp-aarch64-unknown-linux-gnu.tar.gz.sha256
+          curl -fsSL "${BASE}/ferrox-cp-aarch64-unknown-linux-gnu.tar.gz" -o ferrox-cp-aarch64-unknown-linux-gnu.tar.gz
+          curl -fsSL "${BASE}/ferrox-cp-aarch64-unknown-linux-gnu.sha256" -o ferrox-cp-aarch64-unknown-linux-gnu.sha256
+          sha256sum --check ferrox-cp-aarch64-unknown-linux-gnu.sha256
           tar xzf ferrox-cp-aarch64-unknown-linux-gnu.tar.gz
           mv ferrox-cp ferrox-cp-arm64
 


### PR DESCRIPTION
## Root cause

`taiki-e/upload-rust-binary-action` with `checksum: sha256` uploads checksum files named `<binary>-<target>.sha256`, **not** `<binary>-<target>.tar.gz.sha256`.

The Docker download steps were requesting `ferrox-x86_64-unknown-linux-gnu.tar.gz.sha256` → 404.

Confirmed: the actual file in the v0.2.0 release is `ferrox-x86_64-unknown-linux-gnu.sha256` and its content is:
```
c790495e4851bb7a5063f802fa1a29d09c7838a02aed2888f0d313311b9dc153  ferrox-x86_64-unknown-linux-gnu.tar.gz
```
This format is compatible with `sha256sum --check`.

## Fix

Update download URLs in both `docker` and `docker-cp` jobs from `*.tar.gz.sha256` → `*.sha256`. The `sha256sum --check` invocation is also updated to use the new filename (same format, still verifies the `.tar.gz`).