### PR TITLE
ci: extract release binaries into _bin/ to avoid repo dir conflict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,19 +108,21 @@ jobs:
           VERSION="${{ github.ref_name }}"
           BASE="https://github.com/shaharia-lab/ferrox/releases/download/${VERSION}"
 
+          mkdir -p _bin
+
           # amd64 — download tarball + sha256 sidecar, verify, extract
           curl -fsSL "${BASE}/ferrox-x86_64-unknown-linux-gnu.tar.gz" -o ferrox-x86_64-unknown-linux-gnu.tar.gz
           curl -fsSL "${BASE}/ferrox-x86_64-unknown-linux-gnu.sha256" -o ferrox-x86_64-unknown-linux-gnu.sha256
           sha256sum --check ferrox-x86_64-unknown-linux-gnu.sha256
-          tar xzf ferrox-x86_64-unknown-linux-gnu.tar.gz
-          mv ferrox ferrox-amd64
+          tar xzf ferrox-x86_64-unknown-linux-gnu.tar.gz -C _bin
+          mv _bin/ferrox ferrox-amd64
 
           # arm64 — download tarball + sha256 sidecar, verify, extract
           curl -fsSL "${BASE}/ferrox-aarch64-unknown-linux-gnu.tar.gz" -o ferrox-aarch64-unknown-linux-gnu.tar.gz
           curl -fsSL "${BASE}/ferrox-aarch64-unknown-linux-gnu.sha256" -o ferrox-aarch64-unknown-linux-gnu.sha256
           sha256sum --check ferrox-aarch64-unknown-linux-gnu.sha256
-          tar xzf ferrox-aarch64-unknown-linux-gnu.tar.gz
-          mv ferrox ferrox-arm64
+          tar xzf ferrox-aarch64-unknown-linux-gnu.tar.gz -C _bin
+          mv _bin/ferrox ferrox-arm64
 
       - name: Set up QEMU (for multi-arch manifest only — no compilation)
         uses: docker/setup-qemu-action@v3
@@ -178,19 +180,21 @@ jobs:
           VERSION="${{ github.ref_name }}"
           BASE="https://github.com/shaharia-lab/ferrox/releases/download/${VERSION}"
 
+          mkdir -p _bin
+
           # amd64 — download tarball + sha256 sidecar, verify, extract
           curl -fsSL "${BASE}/ferrox-cp-x86_64-unknown-linux-gnu.tar.gz" -o ferrox-cp-x86_64-unknown-linux-gnu.tar.gz
           curl -fsSL "${BASE}/ferrox-cp-x86_64-unknown-linux-gnu.sha256" -o ferrox-cp-x86_64-unknown-linux-gnu.sha256
           sha256sum --check ferrox-cp-x86_64-unknown-linux-gnu.sha256
-          tar xzf ferrox-cp-x86_64-unknown-linux-gnu.tar.gz
-          mv ferrox-cp ferrox-cp-amd64
+          tar xzf ferrox-cp-x86_64-unknown-linux-gnu.tar.gz -C _bin
+          mv _bin/ferrox-cp ferrox-cp-amd64
 
           # arm64 — download tarball + sha256 sidecar, verify, extract
           curl -fsSL "${BASE}/ferrox-cp-aarch64-unknown-linux-gnu.tar.gz" -o ferrox-cp-aarch64-unknown-linux-gnu.tar.gz
           curl -fsSL "${BASE}/ferrox-cp-aarch64-unknown-linux-gnu.sha256" -o ferrox-cp-aarch64-unknown-linux-gnu.sha256
           sha256sum --check ferrox-cp-aarch64-unknown-linux-gnu.sha256
-          tar xzf ferrox-cp-aarch64-unknown-linux-gnu.tar.gz
-          mv ferrox-cp ferrox-cp-arm64
+          tar xzf ferrox-cp-aarch64-unknown-linux-gnu.tar.gz -C _bin
+          mv _bin/ferrox-cp ferrox-cp-arm64
 
       - name: Set up QEMU (for multi-arch manifest only — no compilation)
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Root cause

The workspace (post-checkout) contains `ferrox/` and `ferrox-cp/` directories — the Rust crates. The download step extracts tarballs into the workspace root:

```bash
tar xzf ferrox-x86_64-unknown-linux-gnu.tar.gz  # tries to create file "ferrox"
```

This fails with `tar: ferrox: Cannot open: File exists` because a directory named `ferrox` already exists.

**Verified locally:** reproduced by creating `ferrox/` and `ferrox-cp/` dirs before extraction.

## Fix

Extract into a `_bin/` subdirectory, then move the binary out:

```bash
mkdir -p _bin
tar xzf ferrox-x86_64-unknown-linux-gnu.tar.gz -C _bin
mv _bin/ferrox ferrox-amd64
```

**Verified locally:** both `Dockerfile.release` and `ferrox-cp/Dockerfile.release` build successfully with binaries produced this way.

## Cumulative fixes across PRs #35, #36, and this PR

| PR | Fix |
|----|-----|
| #35 | Added `checksum: sha256` to upload-rust-binary-action (no .sha256 files were uploaded) |
| #36 | Fixed checksum filename from `.tar.gz.sha256` → `.sha256` (taiki-e naming convention) |
| This | Extract into `_bin/` to avoid collision with `ferrox/` and `ferrox-cp/` repo dirs |