### PR TITLE
fix(openai): base_url must include version prefix (breaking change)

### DIFF
--- a/docs/user/providers.md
+++ b/docs/user/providers.md
@@ -27,12 +27,19 @@ providers:
   - name: openai-primary
     type: openai
     api_key: "${OPENAI_API_KEY}"
-    base_url: "https://api.openai.com"
+    base_url: "https://api.openai.com/v1"
 ```
 
 Because Ferrox exposes an OpenAI-compatible API, requests are forwarded with minimal transformation. For streaming, Ferrox injects `stream_options: {include_usage: true}` to get token counts in the final chunk.
 
-**Compatible with any OpenAI-compatible API** (Azure OpenAI, local models via LiteLLM, etc.) by setting `base_url`.
+**Compatible with any OpenAI-compatible API** (Azure OpenAI, local models via LiteLLM, Ollama, etc.) by setting `base_url`.
+
+> **`base_url` convention:** the value must include the API version segment.
+> The adapter appends only `/chat/completions`, so the full request URL is
+> `{base_url}/chat/completions`.  Examples:
+> - OpenAI: `https://api.openai.com/v1`
+> - Ollama: `http://localhost:11434/v1`
+> - Azure OpenAI: `https://<resource>.openai.azure.com/openai/deployments/<deployment>/`
 
 **Required env var:** `OPENAI_API_KEY`
 
@@ -89,6 +96,8 @@ providers:
 ```
 
 GLM uses an OpenAI-compatible API, so Ferrox routes requests through the same adapter as OpenAI with no transformation. All OpenAI features (streaming, tool use, system prompts) work as-is.
+
+The `base_url` already includes GLM's version prefix (`/v4`); the adapter appends `/chat/completions` to produce the correct endpoint `https://api.z.ai/api/paas/v4/chat/completions`.
 
 Available models: `GLM-5.1`, `GLM-5`, `GLM-4.7`, `GLM-4.5-air`.
 

--- a/ferrox/config.schema.json
+++ b/ferrox/config.schema.json
@@ -138,7 +138,11 @@
           "enum": ["anthropic", "openai", "gemini", "bedrock", "glm"]
         },
         "api_key": { "type": "string" },
-        "base_url": { "type": "string", "format": "uri" },
+        "base_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "API base URL including the version prefix. The adapter appends /chat/completions (OpenAI/GLM) or the provider-specific path. Must NOT end with /chat/completions. Examples: 'https://api.openai.com/v1', 'https://api.z.ai/api/paas/v4'."
+        },
         "region": { "type": "string" },
         "timeouts": { "$ref": "#/definitions/TimeoutsConfig" },
         "retry": { "$ref": "#/definitions/RetryConfig" },

--- a/ferrox/config/config.yaml
+++ b/ferrox/config/config.yaml
@@ -82,7 +82,7 @@ providers:
   - name: openai-primary
     type: openai
     api_key: "${OPENAI_API_KEY:-placeholder}"
-    base_url: "https://api.openai.com"
+    base_url: "https://api.openai.com/v1"
 
   - name: gemini-primary
     type: gemini

--- a/ferrox/src/providers/openai.rs
+++ b/ferrox/src/providers/openai.rs
@@ -14,10 +14,21 @@ use crate::types::{
     MessageContent, StopSequences,
 };
 
-const DEFAULT_BASE_URL: &str = "https://api.openai.com";
+/// Default base URL **including the API version prefix**.
+///
+/// `base_url` must include the version segment so that different providers
+/// (e.g. OpenAI `/v1`, GLM `/v4`) can be configured without code changes.
+/// The adapter appends only `/chat/completions`.
+///
+/// **Breaking change from < 0.3.2:** previously the default was
+/// `https://api.openai.com` and the adapter appended `/v1/chat/completions`.
+/// Configs that omit `base_url` are unaffected (the new default includes `/v1`),
+/// but any explicit `base_url` that did not include the version must be updated.
+const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
 
 // ── Adapter ──────────────────────────────────────────────────────────────────
 
+#[derive(Debug)]
 pub struct OpenAIAdapter {
     name: String,
     api_key: String,
@@ -32,6 +43,22 @@ impl OpenAIAdapter {
             .clone()
             .ok_or_else(|| anyhow::anyhow!("OpenAI provider '{}' requires api_key", cfg.name))?;
 
+        let base_url = cfg
+            .base_url
+            .clone()
+            .unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
+
+        // Guard against the most common misconfiguration: a base_url that still
+        // ends with the full endpoint path.  This would produce a double-path
+        // like `.../v1/chat/completions/chat/completions`.
+        if base_url.ends_with("/chat/completions") {
+            anyhow::bail!(
+                "Provider '{}': base_url must not end with '/chat/completions' — \
+                 set it to the versioned API root (e.g. 'https://api.openai.com/v1')",
+                cfg.name
+            );
+        }
+
         let timeouts = cfg.timeouts.as_ref().unwrap_or(&defaults.timeouts);
 
         let client = Client::builder()
@@ -42,12 +69,17 @@ impl OpenAIAdapter {
         Ok(Self {
             name: cfg.name.clone(),
             api_key,
-            base_url: cfg
-                .base_url
-                .clone()
-                .unwrap_or_else(|| DEFAULT_BASE_URL.to_string()),
+            base_url,
             client,
         })
+    }
+
+    /// Returns the chat completions endpoint URL for this provider.
+    ///
+    /// `base_url` is expected to include the API version (e.g. `/v1`, `/v4`).
+    /// The adapter appends only `/chat/completions`.
+    pub(crate) fn completions_url(&self) -> String {
+        format!("{}/chat/completions", self.base_url)
     }
 }
 
@@ -63,7 +95,7 @@ impl ProviderAdapter for OpenAIAdapter {
         model_id: &str,
     ) -> Result<ChatCompletionResponse, ProxyError> {
         let body = build_request_body(req, model_id, false);
-        let url = format!("{}/v1/chat/completions", self.base_url);
+        let url = self.completions_url();
 
         let resp = self
             .client
@@ -102,7 +134,7 @@ impl ProviderAdapter for OpenAIAdapter {
         model_id: &str,
     ) -> Result<ProviderStream, ProxyError> {
         let body = build_request_body(req, model_id, true);
-        let url = format!("{}/v1/chat/completions", self.base_url);
+        let url = self.completions_url();
 
         let resp = self
             .client
@@ -243,5 +275,116 @@ fn build_request_body(req: &ChatCompletionRequest, model_id: &str, stream: bool)
         stop,
         tools,
         tool_choice: req.tool_choice.clone(),
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{DefaultsConfig, ProviderConfig, ProviderType};
+
+    fn defaults() -> DefaultsConfig {
+        DefaultsConfig::default()
+    }
+
+    fn provider_cfg(base_url: Option<&str>) -> ProviderConfig {
+        ProviderConfig {
+            name: "test".to_string(),
+            provider_type: ProviderType::OpenAI,
+            api_key: Some("sk-test".to_string()),
+            base_url: base_url.map(str::to_string),
+            region: None,
+            timeouts: None,
+            retry: None,
+            circuit_breaker: None,
+        }
+    }
+
+    #[test]
+    fn default_base_url_includes_v1() {
+        let adapter = OpenAIAdapter::new(&provider_cfg(None), &defaults()).unwrap();
+        assert_eq!(
+            adapter.completions_url(),
+            "https://api.openai.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn explicit_openai_base_url_with_v1() {
+        let adapter = OpenAIAdapter::new(
+            &provider_cfg(Some("https://api.openai.com/v1")),
+            &defaults(),
+        )
+        .unwrap();
+        assert_eq!(
+            adapter.completions_url(),
+            "https://api.openai.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn glm_v4_base_url() {
+        let adapter = OpenAIAdapter::new(
+            &provider_cfg(Some("https://api.z.ai/api/paas/v4")),
+            &defaults(),
+        )
+        .unwrap();
+        assert_eq!(
+            adapter.completions_url(),
+            "https://api.z.ai/api/paas/v4/chat/completions"
+        );
+    }
+
+    #[test]
+    fn glm_coding_base_url() {
+        let adapter = OpenAIAdapter::new(
+            &provider_cfg(Some("https://api.z.ai/api/coding/paas/v4")),
+            &defaults(),
+        )
+        .unwrap();
+        assert_eq!(
+            adapter.completions_url(),
+            "https://api.z.ai/api/coding/paas/v4/chat/completions"
+        );
+    }
+
+    #[test]
+    fn custom_openai_compatible_base_url() {
+        let adapter = OpenAIAdapter::new(
+            &provider_cfg(Some("http://localhost:11434/v1")),
+            &defaults(),
+        )
+        .unwrap();
+        assert_eq!(
+            adapter.completions_url(),
+            "http://localhost:11434/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn rejects_base_url_ending_with_full_endpoint_path() {
+        let err = OpenAIAdapter::new(
+            &provider_cfg(Some("https://api.openai.com/v1/chat/completions")),
+            &defaults(),
+        )
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("must not end with '/chat/completions'"));
+    }
+
+    #[test]
+    fn rejects_base_url_without_version_that_ends_in_chat_completions() {
+        // Catches the old-style misconfiguration where someone pasted the full URL
+        let err = OpenAIAdapter::new(
+            &provider_cfg(Some("https://api.z.ai/api/paas/v4/chat/completions")),
+            &defaults(),
+        )
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("must not end with '/chat/completions'"));
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause:** The OpenAI adapter hardcoded `/v1/chat/completions` appended to `base_url`. Providers like GLM whose `base_url` already contains a version segment (e.g. `/v4`) ended up hitting `.../v4/v1/chat/completions` — a path that doesn't exist → 404.
- **Fix:** The adapter now appends only `/chat/completions`. `base_url` must include the version prefix (e.g. `https://api.openai.com/v1`).
- **Startup guard:** If `base_url` ends with `/chat/completions` the gateway refuses to start with a clear error message, catching the most common misconfiguration.

## Breaking change

| Provider | Old `base_url` | New `base_url` |
|---|---|---|
| OpenAI | `https://api.openai.com` | `https://api.openai.com/v1` |
| GLM | `https://api.z.ai/api/paas/v4` | unchanged (was already correct) |
| Ollama / LiteLLM | `http://localhost:11434` | `http://localhost:11434/v1` |

Configs that omit `base_url` entirely are unaffected — the default constant now includes `/v1`.

## Changes

- `ferrox/src/providers/openai.rs` — adapter URL construction + startup validation + 7 unit tests
- `ferrox/config/config.yaml` — `openai-primary.base_url` updated
- `ferrox/config.schema.json` — `base_url` description clarified
- `docs/user/providers.md` — OpenAI and GLM sections updated with convention note

## Test plan

- [x] `cargo test -p ferrox providers::openai` — 7 new unit tests (URL construction for OpenAI, GLM standard, GLM Coding, Ollama; misconfiguration rejection)
- [x] `cargo test -p ferrox` — 202 tests, all pass
- [x] `cargo clippy -p ferrox -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)