### PR TITLE
chore: CI/CD supply-chain hardening (#57)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependabot configuration.
+# Scoped to the artifacts hardened in issue #57 so their pins stay current:
+#   - github-actions: SHA-pinned in the workflows (B1)
+#   - docker: base images digest-pinned in the Dockerfile (B3)
+# Dependabot rewrites the pinned commit/digest + `# vX` comment on updates.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build(deps)
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build(deps)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,11 @@ jobs:
   audit:
     name: Security audit
     runs-on: ubuntu-latest
+    # rustsec/audit-check publishes advisories as a Check run, which needs
+    # `checks: write` on top of the workflow's read-only default.
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
       - uses: rustsec/audit-check@e9159ac5f7d7d873ce074ca134da2f445c0a4a61  # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# Least-privilege default token scope. CI only reads the repo; no job here
+# writes contents, packages, or issues. Jobs may widen this locally if needed.
+permissions:
+  contents: read
+
 jobs:
   # ── Format ────────────────────────────────────────────────────────────────────
   # Ensures all Rust code is formatted with `cargo fmt`.
@@ -29,8 +34,8 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4  # stable
         with:
           components: rustfmt
       - run: cargo fmt --all --check
@@ -41,11 +46,11 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4  # stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - run: cargo clippy --workspace -- -D warnings
@@ -73,9 +78,9 @@ jobs:
     env:
       DATABASE_URL: postgres://postgres:testpass@localhost:5432/postgres
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - run: cargo test --workspace -- --test-threads=1
@@ -87,9 +92,9 @@ jobs:
     name: Build (release)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - run: cargo build --release --workspace
@@ -100,8 +105,8 @@ jobs:
     name: Security audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: rustsec/audit-check@v1
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+      - uses: rustsec/audit-check@e9159ac5f7d7d873ce074ca134da2f445c0a4a61  # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # RUSTSEC-2023-0071: timing side-channel in `rsa` crate (Marvin Attack).
@@ -116,8 +121,8 @@ jobs:
     name: UI build & type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "22"
           cache: npm
@@ -132,8 +137,8 @@ jobs:
     name: Validate config schema
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       - run: pip install check-jsonschema
@@ -148,11 +153,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [fmt, clippy, test, build]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
       - name: Build image (verify only — no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: Dockerfile
@@ -171,11 +176,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [fmt, clippy, test, build, ui]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
       - name: Build image (verify only — no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: ferrox-cp/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# Least-privilege default token scope. Jobs widen it locally where needed
+# (upload-assets/docker/docker-cp declare their own writes; homebrew uses a PAT).
+permissions:
+  contents: read
+
 jobs:
   # ── Cross-platform binaries ───────────────────────────────────────────────────
   # Compiles ferrox and ferrox-cp for all four supported targets and uploads the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
       - name: Install protobuf compiler (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -52,7 +52,7 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install protobuf
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -60,7 +60,7 @@ jobs:
       - name: Build admin UI
         run: cd ferrox-cp/ui && npm ci && npm run build
       - name: Upload ferrox binary
-        uses: taiki-e/upload-rust-binary-action@v1
+        uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6  # v1
         with:
           bin: ferrox
           manifest-path: ferrox/Cargo.toml
@@ -68,7 +68,7 @@ jobs:
           checksum: sha256
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload ferrox-cp binary
-        uses: taiki-e/upload-rust-binary-action@v1
+        uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6  # v1
         with:
           bin: ferrox-cp
           manifest-path: ferrox-cp/Cargo.toml
@@ -88,13 +88,13 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -102,7 +102,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -133,10 +133,10 @@ jobs:
           mv _bin/ferrox ferrox-arm64
 
       - name: Set up QEMU (for multi-arch manifest only — no compilation)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
 
       - name: Build and push multi-platform image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: Dockerfile.release
@@ -160,13 +160,13 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -174,7 +174,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/ferrox-cp
           tags: |
@@ -205,10 +205,10 @@ jobs:
           mv _bin/ferrox-cp ferrox-cp-arm64
 
       - name: Set up QEMU (for multi-arch manifest only — no compilation)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
 
       - name: Build and push multi-platform image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: ferrox-cp/Dockerfile.release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Build ─────────────────────────────────────────────────────────────
-FROM rust:1.94-slim-bookworm AS builder
+FROM rust:1.94-slim-bookworm@sha256:cf9dd0ec73e75f827fe59123fff9dc65af1a1c8363c3c31ee8d7f8ad0b6a5fb2 AS builder
 
 # protobuf-compiler required by opentelemetry-otlp/tonic build script
 # git required by build.rs (git rev-parse for version embedding)
@@ -28,7 +28,7 @@ RUN touch ferrox/src/main.rs \
     && cargo build --release -p ferrox
 
 # ── Stage 2: Runtime ──────────────────────────────────────────────────────────
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
Closes #57

## What
Supply-chain hardening for CI/CD (B1/B2/B3 from the issue):
- **B1** — SHA-pin every GitHub Action to a full 40-char commit (with `# vX` comment) in `ci.yml` and `release.yml`, including `dtolnay/rust-toolchain`.
- **B2** — top-level `permissions: { contents: read }` on `ci.yml` (release.yml already scopes per-job).
- **B3** — digest-pin both Docker base images (`rust:1.94-slim-bookworm`, `debian:bookworm-slim`) with `@sha256:`.
- Add `.github/dependabot.yml` (`github-actions` + `docker` ecosystems) so the new pins stay current.

## Scope
Config only — no Rust changes. cargo/npm Dependabot ecosystems intentionally left out (not part of #57).

## Validation
- All `uses:` are 40-hex pinned (verified); YAML valid; actionlint clean locally.
- SHAs resolved from each action's current tag; digests from the multi-arch manifest.