### PR TITLE
fix: streaming usage — report input/prompt tokens (#72)

### DIFF
--- a/ferrox/src/anthropic_types.rs
+++ b/ferrox/src/anthropic_types.rs
@@ -467,6 +467,10 @@ struct StreamState {
     is_first: bool,
     pending: VecDeque<Result<Event, ProxyError>>,
     output_tokens: u32,
+    /// Prompt tokens. OpenAI-format upstreams deliver this only in the final
+    /// chunk's usage (via `stream_options.include_usage`), so we capture it
+    /// whenever a chunk carries usage and emit it in `message_delta`.
+    input_tokens: u32,
     stop_reason: String,
     stream_done: bool,
     /// Whether the text content_block (index 0) has been opened.
@@ -498,6 +502,7 @@ pub fn openai_stream_to_anthropic_sse(
         is_first: true,
         pending: VecDeque::new(),
         output_tokens: 0,
+        input_tokens: 0,
         stop_reason: "end_turn".to_string(),
         stream_done: false,
         text_block_started: false,
@@ -533,6 +538,7 @@ pub fn openai_stream_to_anthropic_sse(
                     }
                     s.pending.push_back(Ok(make_message_delta_event(
                         &s.stop_reason,
+                        s.input_tokens,
                         s.output_tokens,
                     )));
                     s.pending.push_back(Ok(make_message_stop_event()));
@@ -543,6 +549,9 @@ pub fn openai_stream_to_anthropic_sse(
                     // Update accumulated state
                     if let Some(usage) = &chunk.usage {
                         s.output_tokens = usage.completion_tokens;
+                        if usage.prompt_tokens > 0 {
+                            s.input_tokens = usage.prompt_tokens;
+                        }
                     }
                     if let Some(choice) = chunk.choices.first() {
                         if let Some(reason) = &choice.finish_reason {
@@ -696,14 +705,16 @@ fn make_content_block_stop_event(index: u32) -> Event {
         .data(serde_json::json!({"type": "content_block_stop", "index": index}).to_string())
 }
 
-fn make_message_delta_event(stop_reason: &str, output_tokens: u32) -> Event {
+fn make_message_delta_event(stop_reason: &str, input_tokens: u32, output_tokens: u32) -> Event {
+    // Anthropic clients read the authoritative `input_tokens` from `message_delta`
+    // (message_start only carries a placeholder), so surface it here.
     let data = serde_json::json!({
         "type": "message_delta",
         "delta": {
             "stop_reason": stop_reason,
             "stop_sequence": null
         },
-        "usage": {"output_tokens": output_tokens}
+        "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens}
     });
     Event::default()
         .event("message_delta")
@@ -1278,6 +1289,38 @@ mod tests {
         //            delta("Hello"), delta(" world"),
         //            content_block_stop, message_delta, message_stop
         assert_eq!(events.len(), 8);
+    }
+
+    #[tokio::test]
+    async fn message_delta_includes_input_tokens_from_final_usage() {
+        // OpenAI-format upstreams report prompt_tokens only in the final chunk's
+        // usage; it must surface as Anthropic `input_tokens` in message_delta.
+        let mut usage_chunk = make_chunk(None, Some("stop"));
+        usage_chunk.usage = Some(crate::types::Usage {
+            prompt_tokens: 123,
+            completion_tokens: 45,
+            total_tokens: 168,
+        });
+        let chunks: Vec<Result<ChatCompletionChunk, ProxyError>> =
+            vec![Ok(make_chunk(Some("hi"), None)), Ok(usage_chunk)];
+        let inner: ProviderStream = Box::pin(futures::stream::iter(chunks));
+
+        let events: Vec<_> =
+            openai_stream_to_anthropic_sse("m".to_string(), "msg_u".to_string(), inner)
+                .collect()
+                .await;
+        let dump = events
+            .iter()
+            .map(|e| format!("{:?}", e.as_ref().unwrap()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        // Event Debug-formats its buffer as an escaped byte string, so quotes
+        // appear as \"; match the token/value pair rather than exact JSON.
+        assert!(
+            dump.contains(r#"input_tokens\":123"#),
+            "message_delta must carry input_tokens: {dump}"
+        );
+        assert!(dump.contains(r#"output_tokens\":45"#));
     }
 
     #[tokio::test]

--- a/ferrox/src/providers/anthropic_events.rs
+++ b/ferrox/src/providers/anthropic_events.rs
@@ -18,6 +18,10 @@ pub struct AnthropicEventProcessor {
     pending_tool_index: u32,
     pub stop_reason: Option<String>,
     pub usage: Option<Usage>,
+    /// Prompt tokens from the `message_start` event. Anthropic reports
+    /// `input_tokens` there, not in `message_delta`, so we capture it up front
+    /// and fold it into the final usage.
+    input_tokens: u32,
 }
 
 impl AnthropicEventProcessor {
@@ -30,6 +34,7 @@ impl AnthropicEventProcessor {
             pending_tool_index: 0,
             stop_reason: None,
             usage: None,
+            input_tokens: 0,
         }
     }
 
@@ -56,6 +61,14 @@ impl AnthropicEventProcessor {
             "message_start" => {
                 if let Some(id) = v.pointer("/message/id").and_then(|v| v.as_str()) {
                     self.message_id = id.to_string();
+                }
+                // Anthropic delivers prompt tokens in `message_start`, not the
+                // trailing `message_delta`; capture it for the final usage.
+                if let Some(input) = v
+                    .pointer("/message/usage/input_tokens")
+                    .and_then(|t| t.as_u64())
+                {
+                    self.input_tokens = input as u32;
                 }
             }
             "content_block_start" => {
@@ -127,7 +140,7 @@ impl AnthropicEventProcessor {
                     .pointer("/delta/stop_reason")
                     .and_then(|r| r.as_str())
                     .map(map_stop_reason);
-                self.usage = parse_usage_from_message_delta(&v);
+                self.usage = parse_usage_from_message_delta(&v, self.input_tokens);
             }
             "message_stop" => {
                 results.push(Ok(make_final_chunk(
@@ -167,12 +180,12 @@ pub fn map_stop_reason(r: &str) -> String {
     }
 }
 
-fn parse_usage_from_message_delta(v: &Value) -> Option<Usage> {
+fn parse_usage_from_message_delta(v: &Value, input_tokens: u32) -> Option<Usage> {
     let output = v.pointer("/usage/output_tokens").and_then(|t| t.as_u64())? as u32;
     Some(Usage {
-        prompt_tokens: 0,
+        prompt_tokens: input_tokens,
         completion_tokens: output,
-        total_tokens: output,
+        total_tokens: input_tokens + output,
     })
 }
 
@@ -322,6 +335,24 @@ mod tests {
         assert!(results.is_empty());
         assert_eq!(p.stop_reason.as_deref(), Some("stop"));
         assert_eq!(p.usage.as_ref().unwrap().completion_tokens, 42);
+    }
+
+    #[test]
+    fn message_start_input_tokens_flow_into_final_usage() {
+        let mut p = make_processor();
+        // Anthropic reports prompt tokens in message_start, not message_delta.
+        let start =
+            r#"{"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":123}}}"#;
+        p.process("message_start", start, "claude-3", "anthropic");
+        let delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}"#;
+        p.process("message_delta", delta, "claude-3", "anthropic");
+        let usage = p.usage.as_ref().unwrap();
+        assert_eq!(
+            usage.prompt_tokens, 123,
+            "prompt tokens must come from message_start"
+        );
+        assert_eq!(usage.completion_tokens, 7);
+        assert_eq!(usage.total_tokens, 130);
     }
 
     #[test]


### PR DESCRIPTION
Closes #72

## What
Streaming responses reported `input_tokens: 0`, corrupting usage tracking + budgets. Now the prompt-token count is captured and surfaced in `message_delta` on both streaming paths.

- **`ferrox/src/providers/anthropic_events.rs`** (native Anthropic adapter): capture `input_tokens` from the `message_start` event into processor state; fold it into the final `Usage` (`prompt_tokens` + `total_tokens`).
- **`ferrox/src/anthropic_types.rs`** (`openai_stream_to_anthropic_sse`): capture `prompt_tokens` from the final chunk's usage (OpenAI-format upstreams deliver it there via `stream_options.include_usage`) and emit `input_tokens` in the Anthropic `message_delta`.

## Why
Anthropic reports prompt tokens at stream start, OpenAI-format upstreams at stream end — neither matched where the code looked, so it hard-coded `0`. Confirmed in the audit (both `k3` and `glm-5.2` streams showed `input_tokens: 0`).

## Tests
- `message_start_input_tokens_flow_into_final_usage` (Anthropic adapter): `input_tokens` from message_start → final `prompt_tokens`/`total_tokens`.
- `message_delta_includes_input_tokens_from_final_usage` (converter): final-chunk usage → `input_tokens` in `message_delta`.
- Full suite: 218 passed.

## Performance
Hot-path change kept allocation-free (a captured `u32`; no locks/allocations added).