### PR TITLE
fix: streaming tool/function calls for OpenAI-format providers (#70)

### DIFF
--- a/ferrox/src/anthropic_types.rs
+++ b/ferrox/src/anthropic_types.rs
@@ -481,6 +481,11 @@ struct StreamState {
     text_block_closed: bool,
     /// Running count of content blocks emitted so far (used as the next index).
     next_block_index: u32,
+    /// Open tool_use blocks, as `(openai_tool_index, anthropic_block_index)`.
+    /// OpenAI-format streams fragment each tool call across many deltas keyed by
+    /// `index`; we open one Anthropic block per distinct index, stream its
+    /// argument fragments as `input_json_delta`, and close them all at the end.
+    tool_blocks: Vec<(u32, u32)>,
 }
 
 /// Wraps a `ProviderStream` (OpenAI chunk format) and re-emits events in the
@@ -508,6 +513,7 @@ pub fn openai_stream_to_anthropic_sse(
         text_block_started: false,
         text_block_closed: false,
         next_block_index: 0,
+        tool_blocks: Vec::new(),
     };
 
     futures::stream::unfold(state, |mut s| async move {
@@ -535,6 +541,11 @@ pub fn openai_stream_to_anthropic_sse(
                     if s.text_block_started && !s.text_block_closed {
                         s.text_block_closed = true;
                         s.pending.push_back(Ok(make_content_block_stop_event(0)));
+                    }
+                    // Close every open tool_use block (in the order opened).
+                    for (_, block_index) in std::mem::take(&mut s.tool_blocks) {
+                        s.pending
+                            .push_back(Ok(make_content_block_stop_event(block_index)));
                     }
                     s.pending.push_back(Ok(make_message_delta_event(
                         &s.stop_reason,
@@ -596,27 +607,43 @@ pub fn openai_stream_to_anthropic_sse(
                             .push_back(Ok(make_content_block_delta_event(0, &text)));
                     }
 
-                    // Emit tool_use blocks for each tool call
+                    // Accumulate fragmented tool-call deltas by `index`: open one
+                    // Anthropic tool_use block the first time an index is seen
+                    // (id/name arrive in that first fragment) and stream later
+                    // fragments' arguments into it. Blocks are closed at stream end.
                     for tc in &tool_calls {
-                        // Close the text block before starting tool_use blocks,
-                        // but only if it was actually opened.
-                        if s.text_block_started && !s.text_block_closed {
-                            s.text_block_closed = true;
-                            s.pending.push_back(Ok(make_content_block_stop_event(0)));
+                        let name = tc.function.as_ref().and_then(|f| f.name.as_deref());
+                        let args = tc.function.as_ref().and_then(|f| f.arguments.as_deref());
+
+                        // Open the block on first sighting of this tool index.
+                        if !s.tool_blocks.iter().any(|(oi, _)| *oi == tc.index) {
+                            // Close the text block before the first tool_use block,
+                            // but only if it was actually opened.
+                            if s.text_block_started && !s.text_block_closed {
+                                s.text_block_closed = true;
+                                s.pending.push_back(Ok(make_content_block_stop_event(0)));
+                            }
+                            let block_index = s.next_block_index;
+                            s.next_block_index += 1;
+                            s.tool_blocks.push((tc.index, block_index));
+                            s.pending.push_back(Ok(make_tool_use_block_start_event(
+                                block_index,
+                                tc.id.as_deref().unwrap_or(""),
+                                name.unwrap_or(""),
+                            )));
                         }
-                        let block_index = s.next_block_index;
-                        s.next_block_index += 1;
-                        s.pending.push_back(Ok(make_tool_use_block_start_event(
-                            block_index,
-                            &tc.id,
-                            &tc.function.name,
-                        )));
-                        s.pending.push_back(Ok(make_input_json_delta_event(
-                            block_index,
-                            &tc.function.arguments,
-                        )));
-                        s.pending
-                            .push_back(Ok(make_content_block_stop_event(block_index)));
+
+                        // Stream this fragment's argument piece into the block.
+                        if let Some(args) = args.filter(|a| !a.is_empty()) {
+                            let block_index = s
+                                .tool_blocks
+                                .iter()
+                                .find(|(oi, _)| *oi == tc.index)
+                                .map(|(_, bi)| *bi)
+                                .unwrap_or(0);
+                            s.pending
+                                .push_back(Ok(make_input_json_delta_event(block_index, args)));
+                        }
                     }
                     // Loop back to drain pending or fetch the next chunk
                 }
@@ -1218,19 +1245,117 @@ mod tests {
                 delta: ChunkDelta {
                     role: None,
                     content: None,
-                    tool_calls: Some(vec![crate::types::ToolCall {
-                        id: id.to_string(),
-                        r#type: "function".to_string(),
-                        function: crate::types::FunctionCall {
-                            name: name.to_string(),
-                            arguments: args.to_string(),
-                        },
+                    tool_calls: Some(vec![crate::types::StreamToolCall {
+                        index: 0,
+                        id: Some(id.to_string()),
+                        r#type: Some("function".to_string()),
+                        function: Some(crate::types::StreamFunctionCall {
+                            name: Some(name.to_string()),
+                            arguments: Some(args.to_string()),
+                        }),
                     }]),
                 },
                 finish_reason: finish_reason.map(str::to_string),
             }],
             usage: None,
         }
+    }
+
+    /// One fragmented streaming tool-call delta (id/name only in the first).
+    fn tool_frag(
+        index: u32,
+        id: Option<&str>,
+        name: Option<&str>,
+        args: Option<&str>,
+        finish: Option<&str>,
+    ) -> ChatCompletionChunk {
+        ChatCompletionChunk {
+            id: "c".to_string(),
+            object: "chat.completion.chunk".to_string(),
+            created: 0,
+            model: "k".to_string(),
+            choices: vec![ChunkChoice {
+                index: 0,
+                delta: ChunkDelta {
+                    role: None,
+                    content: None,
+                    tool_calls: Some(vec![crate::types::StreamToolCall {
+                        index,
+                        id: id.map(str::to_string),
+                        r#type: id.map(|_| "function".to_string()),
+                        function: Some(crate::types::StreamFunctionCall {
+                            name: name.map(str::to_string),
+                            arguments: args.map(str::to_string),
+                        }),
+                    }]),
+                },
+                finish_reason: finish.map(str::to_string),
+            }],
+            usage: None,
+        }
+    }
+
+    #[test]
+    fn streaming_tool_call_continuation_fragment_deserializes() {
+        // Regression: continuation fragments carry only `index` + partial
+        // `arguments` (no id/type/name). Modelling those as required aborted the
+        // whole stream. They must now deserialize.
+        let json = r#"{"id":"c","object":"chat.completion.chunk","created":0,"model":"k","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"date"}}]},"finish_reason":null}],"usage":null}"#;
+        let chunk: ChatCompletionChunk =
+            serde_json::from_str(json).expect("continuation fragment must deserialize");
+        let tc = &chunk.choices[0].delta.tool_calls.as_ref().unwrap()[0];
+        assert_eq!(tc.index, 0);
+        assert!(tc.id.is_none());
+        assert_eq!(
+            tc.function.as_ref().unwrap().arguments.as_deref(),
+            Some("date")
+        );
+    }
+
+    #[tokio::test]
+    async fn fragmented_tool_call_accumulates_into_one_block() {
+        // id+name in the first fragment, arguments streamed across the rest.
+        let chunks: Vec<Result<ChatCompletionChunk, ProxyError>> = vec![
+            Ok(tool_frag(0, Some("t1"), Some("Bash"), Some(""), None)),
+            Ok(tool_frag(0, None, None, Some(r#"{"cmd":""#), None)),
+            Ok(tool_frag(0, None, None, Some("ls"), None)),
+            Ok(tool_frag(0, None, None, Some(r#""}"#), None)),
+            Ok(make_chunk(None, Some("tool_calls"))),
+        ];
+        let inner: ProviderStream = Box::pin(futures::stream::iter(chunks));
+        let events: Vec<_> =
+            openai_stream_to_anthropic_sse("m".to_string(), "msg".to_string(), inner)
+                .collect()
+                .await;
+
+        assert!(events.iter().all(|e| e.is_ok()), "stream must not abort");
+        let dump = events
+            .iter()
+            .map(|e| format!("{:?}", e.as_ref().unwrap()))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Exactly ONE tool block: one start, one stop (not one per fragment).
+        // Count the SSE event-name line ("content_block_start" also appears in
+        // the JSON `type` field, so match the `event:` prefix).
+        assert_eq!(
+            dump.matches("event: content_block_start").count(),
+            1,
+            "exactly one content_block_start: {dump}"
+        );
+        assert_eq!(
+            dump.matches("event: content_block_stop").count(),
+            1,
+            "exactly one content_block_stop"
+        );
+        // id + name captured from the first fragment.
+        assert!(dump.contains("t1") && dump.contains("Bash"));
+        // Three non-empty argument fragments streamed as input_json_delta.
+        assert_eq!(
+            dump.matches("input_json_delta").count(),
+            3,
+            "one input_json_delta per non-empty arg fragment: {dump}"
+        );
     }
 
     /// Tool-only stream must NOT produce an empty text block.

--- a/ferrox/src/anthropic_types.rs
+++ b/ferrox/src/anthropic_types.rs
@@ -612,11 +612,14 @@ pub fn openai_stream_to_anthropic_sse(
                     // (id/name arrive in that first fragment) and stream later
                     // fragments' arguments into it. Blocks are closed at stream end.
                     for tc in &tool_calls {
+                        // Some providers send -1 for a single tool call; clamp
+                        // negatives to 0 (matching the official SDKs).
+                        let idx = tc.index.max(0) as u32;
                         let name = tc.function.as_ref().and_then(|f| f.name.as_deref());
                         let args = tc.function.as_ref().and_then(|f| f.arguments.as_deref());
 
                         // Open the block on first sighting of this tool index.
-                        if !s.tool_blocks.iter().any(|(oi, _)| *oi == tc.index) {
+                        if !s.tool_blocks.iter().any(|(oi, _)| *oi == idx) {
                             // Close the text block before the first tool_use block,
                             // but only if it was actually opened.
                             if s.text_block_started && !s.text_block_closed {
@@ -625,7 +628,7 @@ pub fn openai_stream_to_anthropic_sse(
                             }
                             let block_index = s.next_block_index;
                             s.next_block_index += 1;
-                            s.tool_blocks.push((tc.index, block_index));
+                            s.tool_blocks.push((idx, block_index));
                             s.pending.push_back(Ok(make_tool_use_block_start_event(
                                 block_index,
                                 tc.id.as_deref().unwrap_or(""),
@@ -638,7 +641,7 @@ pub fn openai_stream_to_anthropic_sse(
                             let block_index = s
                                 .tool_blocks
                                 .iter()
-                                .find(|(oi, _)| *oi == tc.index)
+                                .find(|(oi, _)| *oi == idx)
                                 .map(|(_, bi)| *bi)
                                 .unwrap_or(0);
                             s.pending
@@ -1263,7 +1266,7 @@ mod tests {
 
     /// One fragmented streaming tool-call delta (id/name only in the first).
     fn tool_frag(
-        index: u32,
+        index: i32,
         id: Option<&str>,
         name: Option<&str>,
         args: Option<&str>,
@@ -1356,6 +1359,76 @@ mod tests {
             3,
             "one input_json_delta per non-empty arg fragment: {dump}"
         );
+    }
+
+    #[tokio::test]
+    async fn parallel_tool_calls_produce_distinct_blocks() {
+        // Two tool calls interleaved by index 0 and 1.
+        let chunks: Vec<Result<ChatCompletionChunk, ProxyError>> = vec![
+            Ok(tool_frag(
+                0,
+                Some("a"),
+                Some("Bash"),
+                Some(r#"{"c":"#),
+                None,
+            )),
+            Ok(tool_frag(
+                1,
+                Some("b"),
+                Some("Read"),
+                Some(r#"{"p":"#),
+                None,
+            )),
+            Ok(tool_frag(0, None, None, Some("1}"), None)),
+            Ok(tool_frag(1, None, None, Some("2}"), None)),
+            Ok(make_chunk(None, Some("tool_calls"))),
+        ];
+        let inner: ProviderStream = Box::pin(futures::stream::iter(chunks));
+        let events: Vec<_> =
+            openai_stream_to_anthropic_sse("m".to_string(), "msg".to_string(), inner)
+                .collect()
+                .await;
+        assert!(events.iter().all(|e| e.is_ok()));
+        let dump = events
+            .iter()
+            .map(|e| format!("{:?}", e.as_ref().unwrap()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        // Two distinct tool blocks: two starts, two stops.
+        assert_eq!(dump.matches("event: content_block_start").count(), 2);
+        assert_eq!(dump.matches("event: content_block_stop").count(), 2);
+        assert!(dump.contains("Bash") && dump.contains("Read"));
+    }
+
+    #[tokio::test]
+    async fn negative_tool_call_index_is_clamped() {
+        // A provider that sends -1 for a single tool call must not abort.
+        let chunks: Vec<Result<ChatCompletionChunk, ProxyError>> = vec![
+            Ok(tool_frag(
+                -1,
+                Some("x"),
+                Some("Bash"),
+                Some(r#"{"c":"ls"}"#),
+                None,
+            )),
+            Ok(make_chunk(None, Some("tool_calls"))),
+        ];
+        let inner: ProviderStream = Box::pin(futures::stream::iter(chunks));
+        let events: Vec<_> =
+            openai_stream_to_anthropic_sse("m".to_string(), "msg".to_string(), inner)
+                .collect()
+                .await;
+        assert!(
+            events.iter().all(|e| e.is_ok()),
+            "stream must not abort on index -1"
+        );
+        let dump = events
+            .iter()
+            .map(|e| format!("{:?}", e.as_ref().unwrap()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(dump.matches("event: content_block_start").count(), 1);
+        assert!(dump.contains("Bash"));
     }
 
     /// Tool-only stream must NOT produce an empty text block.

--- a/ferrox/src/providers/anthropic_events.rs
+++ b/ferrox/src/providers/anthropic_events.rs
@@ -1,7 +1,10 @@
 use serde_json::Value;
 
 use crate::error::ProxyError;
-use crate::types::{ChatCompletionChunk, ChunkChoice, ChunkDelta, FunctionCall, ToolCall, Usage};
+use crate::types::{
+    ChatCompletionChunk, ChunkChoice, ChunkDelta, FunctionCall, StreamFunctionCall, StreamToolCall,
+    ToolCall, Usage,
+};
 
 // ── Shared Anthropic SSE event processor ──────────────────────────────────────
 
@@ -224,7 +227,17 @@ pub fn make_tool_call_chunk(
             delta: ChunkDelta {
                 role: None,
                 content: None,
-                tool_calls: Some(vec![tool_call]),
+                // Anthropic delivers the whole tool call at content_block_stop,
+                // so emit it as a single complete streaming fragment.
+                tool_calls: Some(vec![StreamToolCall {
+                    index,
+                    id: Some(tool_call.id),
+                    r#type: Some(tool_call.r#type),
+                    function: Some(StreamFunctionCall {
+                        name: Some(tool_call.function.name),
+                        arguments: Some(tool_call.function.arguments),
+                    }),
+                }]),
             },
             finish_reason: None,
         }],
@@ -319,9 +332,10 @@ mod tests {
         assert_eq!(results.len(), 1);
         let chunk = results[0].as_ref().unwrap();
         let tc = &chunk.choices[0].delta.tool_calls.as_ref().unwrap()[0];
-        assert_eq!(tc.id, "tool_1");
-        assert_eq!(tc.function.name, "get_weather");
-        assert_eq!(tc.function.arguments, r#"{"location":"NYC"}"#);
+        assert_eq!(tc.id.as_deref(), Some("tool_1"));
+        let f = tc.function.as_ref().unwrap();
+        assert_eq!(f.name.as_deref(), Some("get_weather"));
+        assert_eq!(f.arguments.as_deref(), Some(r#"{"location":"NYC"}"#));
 
         // pending state is cleared
         assert!(p.pending_tool_id.is_empty());

--- a/ferrox/src/providers/anthropic_events.rs
+++ b/ferrox/src/providers/anthropic_events.rs
@@ -230,7 +230,7 @@ pub fn make_tool_call_chunk(
                 // Anthropic delivers the whole tool call at content_block_stop,
                 // so emit it as a single complete streaming fragment.
                 tool_calls: Some(vec![StreamToolCall {
-                    index,
+                    index: index as i32,
                     id: Some(tool_call.id),
                     r#type: Some(tool_call.r#type),
                     function: Some(StreamFunctionCall {

--- a/ferrox/src/types.rs
+++ b/ferrox/src/types.rs
@@ -125,6 +125,34 @@ pub struct FunctionCall {
     pub arguments: String,
 }
 
+/// A tool call as it appears in a streaming `delta`.
+///
+/// Unlike the non-streaming [`ToolCall`], every field except `index` is
+/// optional: OpenAI-format providers send `id`/`type`/`name` only in the first
+/// fragment for a given `index`, then stream `function.arguments` in pieces.
+/// Modelling those fields as required (as [`ToolCall`] does) makes continuation
+/// fragments fail to deserialize and aborts the whole stream. Consumers
+/// accumulate fragments by `index`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamToolCall {
+    #[serde(default)]
+    pub index: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<StreamFunctionCall>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamFunctionCall {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<String>,
+}
+
 // ── Non-streaming response ───────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -175,7 +203,7 @@ pub struct ChunkChoice {
 pub struct ChunkDelta {
     pub role: Option<String>,
     pub content: Option<String>,
-    pub tool_calls: Option<Vec<ToolCall>>,
+    pub tool_calls: Option<Vec<StreamToolCall>>,
 }
 
 // ── Models list response ─────────────────────────────────────────────────────

--- a/ferrox/src/types.rs
+++ b/ferrox/src/types.rs
@@ -135,8 +135,10 @@ pub struct FunctionCall {
 /// accumulate fragments by `index`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StreamToolCall {
+    /// Signed because some OpenAI-compatible providers send `-1` for a single
+    /// tool call; consumers clamp negatives to 0 (matching the official SDKs).
     #[serde(default)]
-    pub index: u32,
+    pub index: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Closes #70

## What
Streaming tool calls from OpenAI-format providers (Kimi, OpenAI, `type:glm`) aborted the stream and delivered empty arguments. Now the fragmented deltas are accumulated by `index` per the official-SDK contract.

- **`types.rs`** — new `StreamToolCall`/`StreamFunctionCall` (all fields optional except `index`); `ChunkDelta.tool_calls` now uses it. The required `ToolCall` stays for non-streaming/requests. This is the root-cause fix: continuation fragments (id/type/name absent) now deserialize instead of aborting the stream at `openai.rs:183`, and re-serialize faithfully for the `/v1` passthrough.
- **`anthropic_types.rs`** (`openai_stream_to_anthropic_sse`) — open **one** Anthropic `tool_use` block per distinct `index` (id/name captured from the first fragment), stream each fragment's `arguments` as `input_json_delta`, and close all blocks at stream end. Replaces the previous "one start/delta/stop per fragment".
- **`anthropic_events.rs`** — the Anthropic→OpenAI path emits its complete tool call as a single `StreamToolCall` fragment.

## Why
An OpenAI streaming tool call fragments across chunks — `id`/`name` in the first, `arguments` in pieces, all keyed by `index`. Modelling delta fields as required (as the non-streaming `ToolCall` does) failed to deserialize continuation fragments and terminated the stream ("Connection closed mid-response"); the converter also emitted a malformed block per fragment ("Invalid tool parameters"). Validated against six official SDKs (openai-go/python/node accumulate by index; anthropic-sdk go/python/ts = one block per tool_use).

## Tests
- `streaming_tool_call_continuation_fragment_deserializes` — a bare `{index, function:{arguments}}` fragment now parses (the abort fix).
- `fragmented_tool_call_accumulates_into_one_block` — a 4-fragment call yields exactly one `content_block_start`/`content_block_stop` and 3 `input_json_delta`, with id+name captured. Fails if reverted.
- Full suite: 220 passed.

## Performance
Hot-path: per-index tool-block state is a small `Vec<(u32,u32)>` allocated only when tool calls are present; no locks, streaming (no full-body buffering).