### PR TITLE
fix: preserve reasoning/thinking content (#71)

### DIFF
--- a/ferrox/src/anthropic_types.rs
+++ b/ferrox/src/anthropic_types.rs
@@ -641,7 +641,10 @@ pub fn openai_stream_to_anthropic_sse(
                     }
 
                     // Thinking (reasoning) block — opened first, before text/tools.
-                    if !reasoning.is_empty() {
+                    // Ignore reasoning that arrives after the block was closed
+                    // (e.g. reasoning interleaved after text) to avoid emitting a
+                    // delta into a stopped block.
+                    if !reasoning.is_empty() && !s.thinking_closed {
                         if !s.thinking_started {
                             s.thinking_started = true;
                             s.thinking_index = s.next_block_index;

--- a/ferrox/src/anthropic_types.rs
+++ b/ferrox/src/anthropic_types.rs
@@ -142,6 +142,11 @@ pub struct AnthropicMessagesResponse {
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AnthropicResponseContent {
+    /// Extended-thinking block (emitted before text when a reasoning model
+    /// returned `reasoning_content`).
+    Thinking {
+        thinking: String,
+    },
     Text {
         text: String,
     },
@@ -261,6 +266,7 @@ fn anthropic_messages_to_internal(messages: Vec<AnthropicMessage>) -> Vec<ChatMe
                     name: None,
                     tool_calls: None,
                     tool_call_id: None,
+                    reasoning_content: None,
                 });
             }
             AnthropicMessageContent::Blocks(blocks) => {
@@ -323,6 +329,7 @@ fn convert_blocks(role: String, blocks: Vec<AnthropicContentBlock>, out: &mut Ve
                 Some(tool_calls)
             },
             tool_call_id: None,
+            reasoning_content: None,
         });
     } else {
         // User turn: text first, then each tool result as a separate "tool" message.
@@ -334,6 +341,7 @@ fn convert_blocks(role: String, blocks: Vec<AnthropicContentBlock>, out: &mut Ve
                 name: None,
                 tool_calls: None,
                 tool_call_id: None,
+                reasoning_content: None,
             });
         }
         for (tool_use_id, content) in tool_results {
@@ -343,6 +351,7 @@ fn convert_blocks(role: String, blocks: Vec<AnthropicContentBlock>, out: &mut Ve
                 name: None,
                 tool_calls: None,
                 tool_call_id: Some(tool_use_id),
+                reasoning_content: None,
             });
         }
     }
@@ -383,6 +392,15 @@ pub fn to_anthropic_response(resp: ChatCompletionResponse) -> AnthropicMessagesR
     let mut content: Vec<AnthropicResponseContent> = Vec::new();
 
     if let Some(ref c) = choice {
+        // Thinking block first (reasoning models return reasoning_content).
+        if let Some(thinking) = c.message.reasoning_content.as_ref() {
+            if !thinking.is_empty() {
+                content.push(AnthropicResponseContent::Thinking {
+                    thinking: thinking.clone(),
+                });
+            }
+        }
+
         // Text content
         if let Some(msg_content) = c.message.content.as_ref() {
             let text = match msg_content {
@@ -486,6 +504,16 @@ struct StreamState {
     /// `index`; we open one Anthropic block per distinct index, stream its
     /// argument fragments as `input_json_delta`, and close them all at the end.
     tool_blocks: Vec<(u32, u32)>,
+    /// Block index assigned to the text content block (0 unless a thinking block
+    /// precedes it). Text is no longer hard-coded to index 0 because a `thinking`
+    /// block, when present, must come first.
+    text_block_index: u32,
+    /// Thinking (reasoning) block state. Reasoning models stream chain-of-thought
+    /// via `reasoning_content`; it is surfaced as an Anthropic `thinking` block
+    /// that precedes text/tool blocks.
+    thinking_started: bool,
+    thinking_closed: bool,
+    thinking_index: u32,
 }
 
 /// Wraps a `ProviderStream` (OpenAI chunk format) and re-emits events in the
@@ -514,6 +542,10 @@ pub fn openai_stream_to_anthropic_sse(
         text_block_closed: false,
         next_block_index: 0,
         tool_blocks: Vec::new(),
+        text_block_index: 0,
+        thinking_started: false,
+        thinking_closed: false,
+        thinking_index: 0,
     };
 
     futures::stream::unfold(state, |mut s| async move {
@@ -537,10 +569,16 @@ pub fn openai_stream_to_anthropic_sse(
                             .push_back(Ok(make_message_start_event(&s.msg_id, &s.model, 0)));
                         s.pending.push_back(Ok(make_ping_event()));
                     }
-                    // Close the text block only if it was actually opened
+                    // Close any still-open thinking/text block.
+                    if s.thinking_started && !s.thinking_closed {
+                        s.thinking_closed = true;
+                        s.pending
+                            .push_back(Ok(make_content_block_stop_event(s.thinking_index)));
+                    }
                     if s.text_block_started && !s.text_block_closed {
                         s.text_block_closed = true;
-                        s.pending.push_back(Ok(make_content_block_stop_event(0)));
+                        s.pending
+                            .push_back(Ok(make_content_block_stop_event(s.text_block_index)));
                     }
                     // Close every open tool_use block (in the order opened).
                     for (_, block_index) in std::mem::take(&mut s.tool_blocks) {
@@ -582,6 +620,12 @@ pub fn openai_stream_to_anthropic_sse(
                         .and_then(|c| c.delta.tool_calls.clone())
                         .unwrap_or_default();
 
+                    let reasoning = chunk
+                        .choices
+                        .first()
+                        .and_then(|c| c.delta.reasoning_content.clone())
+                        .unwrap_or_default();
+
                     if s.is_first {
                         s.is_first = false;
                         let input_tokens =
@@ -596,15 +640,38 @@ pub fn openai_stream_to_anthropic_sse(
                         // so tool-only responses never produce an empty text block.
                     }
 
+                    // Thinking (reasoning) block — opened first, before text/tools.
+                    if !reasoning.is_empty() {
+                        if !s.thinking_started {
+                            s.thinking_started = true;
+                            s.thinking_index = s.next_block_index;
+                            s.next_block_index += 1;
+                            s.pending
+                                .push_back(Ok(make_thinking_block_start_event(s.thinking_index)));
+                        }
+                        s.pending
+                            .push_back(Ok(make_thinking_delta_event(s.thinking_index, &reasoning)));
+                    }
+
                     if !text.is_empty() {
+                        // Thinking always closes before the text block opens.
+                        if s.thinking_started && !s.thinking_closed {
+                            s.thinking_closed = true;
+                            s.pending
+                                .push_back(Ok(make_content_block_stop_event(s.thinking_index)));
+                        }
                         // Open the text block on first actual text content.
                         if !s.text_block_started {
                             s.text_block_started = true;
-                            s.pending.push_back(Ok(make_content_block_start_event(0)));
-                            s.next_block_index = 1;
+                            s.text_block_index = s.next_block_index;
+                            s.next_block_index += 1;
+                            s.pending
+                                .push_back(Ok(make_content_block_start_event(s.text_block_index)));
                         }
-                        s.pending
-                            .push_back(Ok(make_content_block_delta_event(0, &text)));
+                        s.pending.push_back(Ok(make_content_block_delta_event(
+                            s.text_block_index,
+                            &text,
+                        )));
                     }
 
                     // Accumulate fragmented tool-call deltas by `index`: open one
@@ -620,11 +687,18 @@ pub fn openai_stream_to_anthropic_sse(
 
                         // Open the block on first sighting of this tool index.
                         if !s.tool_blocks.iter().any(|(oi, _)| *oi == idx) {
-                            // Close the text block before the first tool_use block,
-                            // but only if it was actually opened.
+                            // Close any open thinking/text block before the first
+                            // tool_use block.
+                            if s.thinking_started && !s.thinking_closed {
+                                s.thinking_closed = true;
+                                s.pending
+                                    .push_back(Ok(make_content_block_stop_event(s.thinking_index)));
+                            }
                             if s.text_block_started && !s.text_block_closed {
                                 s.text_block_closed = true;
-                                s.pending.push_back(Ok(make_content_block_stop_event(0)));
+                                s.pending.push_back(Ok(make_content_block_stop_event(
+                                    s.text_block_index,
+                                )));
                             }
                             let block_index = s.next_block_index;
                             s.next_block_index += 1;
@@ -698,6 +772,28 @@ fn make_tool_use_block_start_event(index: u32, id: &str, name: &str) -> Event {
     });
     Event::default()
         .event("content_block_start")
+        .data(data.to_string())
+}
+
+fn make_thinking_block_start_event(index: u32) -> Event {
+    let data = serde_json::json!({
+        "type": "content_block_start",
+        "index": index,
+        "content_block": {"type": "thinking", "thinking": ""}
+    });
+    Event::default()
+        .event("content_block_start")
+        .data(data.to_string())
+}
+
+fn make_thinking_delta_event(index: u32, thinking: &str) -> Event {
+    let data = serde_json::json!({
+        "type": "content_block_delta",
+        "index": index,
+        "delta": {"type": "thinking_delta", "thinking": thinking}
+    });
+    Event::default()
+        .event("content_block_delta")
         .data(data.to_string())
 }
 
@@ -1076,6 +1172,7 @@ mod tests {
                     name: None,
                     tool_calls: None,
                     tool_call_id: None,
+                    reasoning_content: None,
                 },
                 finish_reason: Some(finish_reason.to_string()),
             }],
@@ -1155,6 +1252,7 @@ mod tests {
                         },
                     }]),
                     tool_call_id: None,
+                    reasoning_content: None,
                 },
                 finish_reason: Some("tool_calls".to_string()),
             }],
@@ -1225,6 +1323,7 @@ mod tests {
                     role: None,
                     content: content.map(str::to_string),
                     tool_calls: None,
+                    reasoning_content: None,
                 },
                 finish_reason: finish_reason.map(str::to_string),
             }],
@@ -1257,6 +1356,7 @@ mod tests {
                             arguments: Some(args.to_string()),
                         }),
                     }]),
+                    reasoning_content: None,
                 },
                 finish_reason: finish_reason.map(str::to_string),
             }],
@@ -1291,6 +1391,7 @@ mod tests {
                             arguments: args.map(str::to_string),
                         }),
                     }]),
+                    reasoning_content: None,
                 },
                 finish_reason: finish.map(str::to_string),
             }],
@@ -1429,6 +1530,40 @@ mod tests {
             .join("\n");
         assert_eq!(dump.matches("event: content_block_start").count(), 1);
         assert!(dump.contains("Bash"));
+    }
+
+    #[tokio::test]
+    async fn reasoning_content_emits_thinking_block_before_text() {
+        let mut r_chunk = make_chunk(None, None);
+        r_chunk.choices[0].delta.reasoning_content = Some("pondering".to_string());
+        let chunks: Vec<Result<ChatCompletionChunk, ProxyError>> = vec![
+            Ok(r_chunk),
+            Ok(make_chunk(Some("answer"), None)),
+            Ok(make_chunk(None, Some("stop"))),
+        ];
+        let inner: ProviderStream = Box::pin(futures::stream::iter(chunks));
+        let events: Vec<_> =
+            openai_stream_to_anthropic_sse("m".to_string(), "msg".to_string(), inner)
+                .collect()
+                .await;
+        assert!(events.iter().all(|e| e.is_ok()));
+        let dump = events
+            .iter()
+            .map(|e| format!("{:?}", e.as_ref().unwrap()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        // A thinking block with a thinking_delta is emitted.
+        assert!(
+            dump.contains("thinking_delta"),
+            "thinking_delta emitted: {dump}"
+        );
+        assert!(dump.contains("pondering"));
+        // Thinking precedes text; two content blocks open (thinking + text).
+        assert!(
+            dump.find("pondering").unwrap() < dump.find("answer").unwrap(),
+            "thinking must precede text"
+        );
+        assert_eq!(dump.matches("event: content_block_start").count(), 2);
     }
 
     /// Tool-only stream must NOT produce an empty text block.

--- a/ferrox/src/providers/anthropic.rs
+++ b/ferrox/src/providers/anthropic.rs
@@ -470,6 +470,16 @@ enum AnthropicResponseContent {
         name: String,
         input: Value,
     },
+    /// Extended-thinking block. Modelled so a thinking response deserializes
+    /// (previously it failed the whole response) and is surfaced as
+    /// `reasoning_content`.
+    Thinking {
+        #[serde(default)]
+        thinking: String,
+    },
+    /// Any other block type (e.g. redacted_thinking) — ignored, not fatal.
+    #[serde(other)]
+    Other,
 }
 
 #[derive(Deserialize)]
@@ -480,12 +490,16 @@ struct AnthropicUsage {
 
 fn anthropic_to_openai_response(resp: AnthropicResponse, model_id: &str) -> ChatCompletionResponse {
     let mut text_content = String::new();
+    let mut reasoning = String::new();
     let mut tool_calls = Vec::new();
 
     for content in resp.content {
         match content {
             AnthropicResponseContent::Text { text } => {
                 text_content.push_str(&text);
+            }
+            AnthropicResponseContent::Thinking { thinking } => {
+                reasoning.push_str(&thinking);
             }
             AnthropicResponseContent::ToolUse { id, name, input } => {
                 tool_calls.push(crate::types::ToolCall {
@@ -497,6 +511,7 @@ fn anthropic_to_openai_response(resp: AnthropicResponse, model_id: &str) -> Chat
                     },
                 });
             }
+            AnthropicResponseContent::Other => {}
         }
     }
 
@@ -514,6 +529,11 @@ fn anthropic_to_openai_response(resp: AnthropicResponse, model_id: &str) -> Chat
             Some(tool_calls)
         },
         tool_call_id: None,
+        reasoning_content: if reasoning.is_empty() {
+            None
+        } else {
+            Some(reasoning)
+        },
     };
 
     let finish_reason = resp.stop_reason.map(|r| match r.as_str() {

--- a/ferrox/src/providers/anthropic.rs
+++ b/ferrox/src/providers/anthropic.rs
@@ -604,3 +604,34 @@ fn transform_stream(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thinking_block_deserializes_and_maps_to_reasoning() {
+        // Regression: a response containing a `thinking` block previously failed
+        // to deserialize entirely. It must parse and surface as reasoning_content.
+        let json = r#"{"id":"m","model":"glm","content":[{"type":"thinking","thinking":"reasoning here"},{"type":"text","text":"answer"}],"stop_reason":"end_turn","usage":{"input_tokens":5,"output_tokens":3}}"#;
+        let resp: AnthropicResponse =
+            serde_json::from_str(json).expect("thinking response must deserialize");
+        let out = anthropic_to_openai_response(resp, "glm");
+        let msg = &out.choices[0].message;
+        assert_eq!(msg.reasoning_content.as_deref(), Some("reasoning here"));
+        assert!(
+            matches!(&msg.content, Some(crate::types::MessageContent::Text(t)) if t == "answer")
+        );
+    }
+
+    #[test]
+    fn unknown_content_block_is_ignored_not_fatal() {
+        let json = r#"{"id":"m","model":"x","content":[{"type":"redacted_thinking","data":"..."},{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":null}"#;
+        let resp: AnthropicResponse =
+            serde_json::from_str(json).expect("unknown block must not be fatal");
+        let out = anthropic_to_openai_response(resp, "x");
+        assert!(
+            matches!(&out.choices[0].message.content, Some(crate::types::MessageContent::Text(t)) if t == "hi")
+        );
+    }
+}

--- a/ferrox/src/providers/anthropic_events.rs
+++ b/ferrox/src/providers/anthropic_events.rs
@@ -114,6 +114,21 @@ impl AnthropicEventProcessor {
                             .unwrap_or("");
                         self.pending_tool_args.push_str(partial);
                     }
+                    "thinking_delta" => {
+                        // Extended-thinking text → OpenAI-style reasoning_content.
+                        let thinking = v
+                            .pointer("/delta/thinking")
+                            .and_then(|t| t.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        if !thinking.is_empty() {
+                            results.push(Ok(make_reasoning_chunk(
+                                &self.message_id,
+                                model_id,
+                                thinking,
+                            )));
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -204,6 +219,27 @@ pub fn make_text_chunk(id: &str, model: &str, text: String) -> ChatCompletionChu
                 role: None,
                 content: Some(text),
                 tool_calls: None,
+                reasoning_content: None,
+            },
+            finish_reason: None,
+        }],
+        usage: None,
+    }
+}
+
+pub fn make_reasoning_chunk(id: &str, model: &str, thinking: String) -> ChatCompletionChunk {
+    ChatCompletionChunk {
+        id: id.to_string(),
+        object: "chat.completion.chunk".to_string(),
+        created: chrono::Utc::now().timestamp() as u64,
+        model: model.to_string(),
+        choices: vec![ChunkChoice {
+            index: 0,
+            delta: ChunkDelta {
+                role: None,
+                content: None,
+                tool_calls: None,
+                reasoning_content: Some(thinking),
             },
             finish_reason: None,
         }],
@@ -238,6 +274,7 @@ pub fn make_tool_call_chunk(
                         arguments: Some(tool_call.function.arguments),
                     }),
                 }]),
+                reasoning_content: None,
             },
             finish_reason: None,
         }],
@@ -262,6 +299,7 @@ pub fn make_final_chunk(
                 role: None,
                 content: None,
                 tool_calls: None,
+                reasoning_content: None,
             },
             finish_reason: stop_reason,
         }],
@@ -339,6 +377,18 @@ mod tests {
 
         // pending state is cleared
         assert!(p.pending_tool_id.is_empty());
+    }
+
+    #[test]
+    fn thinking_delta_yields_reasoning_chunk() {
+        let mut p = make_processor();
+        let data =
+            r#"{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"hmm"}}"#;
+        let results = p.process("content_block_delta", data, "claude-3", "anthropic");
+        assert_eq!(results.len(), 1);
+        let delta = &results[0].as_ref().unwrap().choices[0].delta;
+        assert_eq!(delta.reasoning_content.as_deref(), Some("hmm"));
+        assert!(delta.content.is_none());
     }
 
     #[test]

--- a/ferrox/src/providers/bedrock.rs
+++ b/ferrox/src/providers/bedrock.rs
@@ -245,6 +245,7 @@ fn bedrock_anthropic_to_openai(resp: &Value, model_id: &str) -> ChatCompletionRe
         name: None,
         tool_calls: None,
         tool_call_id: None,
+        reasoning_content: None,
     };
 
     ChatCompletionResponse {

--- a/ferrox/src/providers/gemini.rs
+++ b/ferrox/src/providers/gemini.rs
@@ -199,6 +199,7 @@ impl ProviderAdapter for GeminiAdapter {
                             role: None,
                             content: if text.is_empty() { None } else { Some(text) },
                             tool_calls: None,
+                            reasoning_content: None,
                         },
                         finish_reason,
                     }],
@@ -450,6 +451,7 @@ fn gemini_to_openai_response(resp: GeminiResponse, model_id: &str) -> ChatComple
                 name: None,
                 tool_calls: None,
                 tool_call_id: None,
+                reasoning_content: None,
             };
 
             Choice {

--- a/ferrox/src/providers/openai.rs
+++ b/ferrox/src/providers/openai.rs
@@ -240,6 +240,7 @@ fn build_request_body(req: &ChatCompletionRequest, model_id: &str, stream: bool)
                     name: None,
                     tool_calls: None,
                     tool_call_id: None,
+                    reasoning_content: None,
                 },
             );
         }

--- a/ferrox/src/types.rs
+++ b/ferrox/src/types.rs
@@ -70,6 +70,11 @@ pub struct ChatMessage {
     pub name: Option<String>,
     pub tool_calls: Option<Vec<ToolCall>>,
     pub tool_call_id: Option<String>,
+    /// Chain-of-thought / extended-thinking text. Reasoning models on
+    /// OpenAI-compatible APIs (Kimi, GLM, DeepSeek) return this alongside
+    /// `content`; preserved so it round-trips instead of being dropped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -206,6 +211,9 @@ pub struct ChunkDelta {
     pub role: Option<String>,
     pub content: Option<String>,
     pub tool_calls: Option<Vec<StreamToolCall>>,
+    /// Streaming chain-of-thought delta (Kimi/GLM/DeepSeek emit `reasoning_content`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
 }
 
 // ── Models list response ─────────────────────────────────────────────────────
@@ -299,6 +307,7 @@ mod tests {
             name: None,
             tool_calls: None,
             tool_call_id: None,
+            reasoning_content: None,
         }
     }
 
@@ -346,6 +355,7 @@ mod tests {
             name: None,
             tool_calls: None,
             tool_call_id: None,
+            reasoning_content: None,
         });
         assert_eq!(r.system_message(), Some("Part1 Part2".to_string()));
     }
@@ -359,6 +369,7 @@ mod tests {
             name: None,
             tool_calls: None,
             tool_call_id: None,
+            reasoning_content: None,
         });
         assert_eq!(r.system_message(), None);
     }


### PR DESCRIPTION
Closes #71

## What
Reasoning / extended-thinking content was dropped on every path. Now preserved end-to-end.

- **`types.rs`** — `reasoning_content: Option<String>` on `ChatMessage` + `ChunkDelta` (skip-if-none). Kimi/GLM/DeepSeek `reasoning_content` is no longer dropped at deserialize; it round-trips on the `/v1` passthrough.
- **`anthropic_types.rs`** — the OpenAI→Anthropic converter emits a `thinking` content block (before text) with `thinking_delta` from `reasoning_content` (streaming), and a `thinking` block in non-streaming `to_anthropic_response`. Text block index is now dynamic (thinking precedes it).
- **`providers/anthropic.rs`** — the response enum gains `Thinking` (+ ignore-unknown `Other`) so a thinking response no longer **fails to deserialize** (was a hard error); thinking maps to `reasoning_content`.
- **`providers/anthropic_events.rs`** — `thinking_delta` (GLM native stream) → a `reasoning_content` chunk.

## Why
Reasoning-first models (Kimi K3, GLM) return `reasoning_content` (OpenAI-style) or `thinking` blocks (Anthropic-style); the code modelled neither, so extended thinking vanished and — worse — an Anthropic `thinking` response crashed deserialization. Validated against the Anthropic SDKs (thinking is a first-class content block; `thinking_delta`/`signature_delta`).

## Tests
- `reasoning_content_emits_thinking_block_before_text` — reasoning delta → thinking block ordered before text; two content blocks.
- `thinking_delta_yields_reasoning_chunk` — Anthropic `thinking_delta` → `reasoning_content` chunk.
- Full suite: 224 passed (existing text-index tests unregressed).

## Performance
Hot path: reasoning string cloned only when present; small added block-index state; no locks.