### PR TITLE
fix: pass-through, stop_reason mapping, mid-stream error events (#75)

### DIFF
--- a/ferrox/src/anthropic_types.rs
+++ b/ferrox/src/anthropic_types.rs
@@ -192,7 +192,9 @@ pub fn to_chat_completion_request(req: AnthropicMessagesRequest) -> ChatCompleti
             .filter(|b| b.block_type == "text")
             .filter_map(|b| b.text)
             .collect::<Vec<_>>()
-            .join(""),
+            // Separate system blocks are distinct lines; joining with "" would
+            // glue e.g. "You are" + "helpful" into "You arehelpful".
+            .join("\n"),
     });
 
     let messages = anthropic_messages_to_internal(req.messages);
@@ -472,7 +474,11 @@ pub fn finish_reason_to_anthropic(reason: &str) -> &str {
         "stop" => "end_turn",
         "length" => "max_tokens",
         "tool_calls" => "tool_use",
-        other => other,
+        // `content_filter` is not a valid Anthropic stop_reason; `refusal` is the
+        // closest. Any other/unknown value defaults to `end_turn` rather than
+        // leaking a non-spec value that strict SDK enums would reject.
+        "content_filter" => "refusal",
+        _ => "end_turn",
     }
 }
 
@@ -593,7 +599,13 @@ pub fn openai_stream_to_anthropic_sse(
                     s.pending.push_back(Ok(make_message_stop_event()));
                     // Loop back to drain pending
                 }
-                Some(Err(e)) => return Some((Err(e), s)),
+                Some(Err(e)) => {
+                    // Emit a proper Anthropic `error` SSE event instead of yielding
+                    // a raw Err (which axum turns into a bare connection close with
+                    // no terminal event). Then end the stream.
+                    s.stream_done = true;
+                    return Some((Ok(make_error_event(&e)), s));
+                }
                 Some(Ok(chunk)) => {
                     // Update accumulated state
                     if let Some(usage) = &chunk.usage {
@@ -776,6 +788,24 @@ fn make_tool_use_block_start_event(index: u32, id: &str, name: &str) -> Event {
     Event::default()
         .event("content_block_start")
         .data(data.to_string())
+}
+
+fn make_error_event(e: &ProxyError) -> Event {
+    let (error_type, message) = match e {
+        ProxyError::Unauthorized(m) => ("authentication_error", m.clone()),
+        ProxyError::Forbidden(m) => ("permission_error", m.clone()),
+        ProxyError::ModelNotFound(m) => ("not_found_error", m.clone()),
+        ProxyError::RateLimited(m) | ProxyError::BudgetExceeded(m) => {
+            ("rate_limit_error", m.clone())
+        }
+        ProxyError::CircuitOpen(m) => ("overloaded_error", m.clone()),
+        other => ("api_error", other.to_string()),
+    };
+    let data = serde_json::json!({
+        "type": "error",
+        "error": {"type": error_type, "message": message}
+    });
+    Event::default().event("error").data(data.to_string())
 }
 
 fn make_thinking_block_start_event(index: u32) -> Event {
@@ -1274,11 +1304,11 @@ mod tests {
     // ── finish_reason_to_anthropic ────────────────────────────────────────────
 
     #[test]
-    fn finish_reason_passthrough_for_unknown() {
-        assert_eq!(
-            finish_reason_to_anthropic("content_filter"),
-            "content_filter"
-        );
+    fn finish_reason_unknowns_do_not_leak() {
+        // content_filter maps to the valid Anthropic `refusal`; anything else
+        // defaults to `end_turn` rather than leaking a non-spec value.
+        assert_eq!(finish_reason_to_anthropic("content_filter"), "refusal");
+        assert_eq!(finish_reason_to_anthropic("mystery"), "end_turn");
     }
 
     // ── tool_result_content_to_string ─────────────────────────────────────────
@@ -1673,8 +1703,41 @@ mod tests {
         assert!(events.iter().all(|e| e.is_ok()));
     }
 
+    #[test]
+    fn finish_reason_maps_content_filter_and_unknowns() {
+        assert_eq!(finish_reason_to_anthropic("content_filter"), "refusal");
+        assert_eq!(finish_reason_to_anthropic("something_new"), "end_turn");
+        assert_eq!(finish_reason_to_anthropic("tool_calls"), "tool_use");
+    }
+
     #[tokio::test]
-    async fn stream_propagates_error() {
+    async fn mid_stream_error_emits_anthropic_error_event() {
+        let chunks: Vec<Result<ChatCompletionChunk, ProxyError>> = vec![
+            Ok(make_chunk(Some("hi"), None)),
+            Err(ProxyError::RateLimited("slow down".to_string())),
+        ];
+        let inner: ProviderStream = Box::pin(futures::stream::iter(chunks));
+        let events: Vec<_> =
+            openai_stream_to_anthropic_sse("m".to_string(), "msg".to_string(), inner)
+                .collect()
+                .await;
+        // Every event is Ok — the error surfaces as an SSE `error` event, not a
+        // raw stream error (which would close the connection with no terminal event).
+        assert!(events.iter().all(|e| e.is_ok()), "no raw stream errors");
+        let dump = events
+            .iter()
+            .map(|e| format!("{:?}", e.as_ref().unwrap()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            dump.contains("event: error"),
+            "an error event is emitted: {dump}"
+        );
+        assert!(dump.contains("rate_limit_error"));
+    }
+
+    #[tokio::test]
+    async fn stream_surfaces_error_as_error_event() {
         let chunks: Vec<Result<ChatCompletionChunk, ProxyError>> = vec![
             Ok(make_chunk(Some("Hi"), None)),
             Err(ProxyError::StreamError("broken".to_string())),
@@ -1686,8 +1749,15 @@ mod tests {
                 .collect()
                 .await;
 
-        // Should contain the error somewhere
-        assert!(events.iter().any(|e| e.is_err()));
+        // The upstream error is surfaced as an Anthropic `error` SSE event, not a
+        // raw stream Err (which would drop the connection with no terminal event).
+        assert!(events.iter().all(|e| e.is_ok()));
+        let dump = events
+            .iter()
+            .map(|e| format!("{:?}", e.as_ref().unwrap()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(dump.contains("event: error"));
     }
 
     #[tokio::test]

--- a/ferrox/src/providers/openai.rs
+++ b/ferrox/src/providers/openai.rs
@@ -231,6 +231,21 @@ struct StreamOptions {
     include_usage: bool,
 }
 
+/// Keys `OpenAIRequest` serialises explicitly; excluded from the `extra`
+/// flatten pass-through so a client-supplied duplicate can't emit a repeated key.
+const RESERVED_REQUEST_KEYS: &[&str] = &[
+    "model",
+    "messages",
+    "stream",
+    "stream_options",
+    "temperature",
+    "max_tokens",
+    "top_p",
+    "stop",
+    "tools",
+    "tool_choice",
+];
+
 fn build_request_body(req: &ChatCompletionRequest, model_id: &str, stream: bool) -> OpenAIRequest {
     // Build messages: if there's a system convenience field, prepend it as a system message
     let mut messages = req.messages.clone();
@@ -282,11 +297,13 @@ fn build_request_body(req: &ChatCompletionRequest, model_id: &str, stream: bool)
         tools,
         tool_choice: req.tool_choice.clone(),
         // Forward client-supplied pass-through fields. Internal `_`-prefixed keys
-        // (e.g. `_anthropic_thinking`) are gateway-private and never sent upstream.
+        // (e.g. `_anthropic_thinking`) are gateway-private, and keys OpenAIRequest
+        // sets explicitly are skipped so `#[serde(flatten)]` can't emit a duplicate
+        // JSON key (e.g. a client-sent `stream_options`).
         extra: req
             .extra
             .iter()
-            .filter(|(k, _)| !k.starts_with('_'))
+            .filter(|(k, _)| !k.starts_with('_') && !RESERVED_REQUEST_KEYS.contains(&k.as_str()))
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect(),
     }
@@ -385,6 +402,34 @@ mod tests {
             json.get("_anthropic_thinking").is_none(),
             "internal `_`-prefixed keys must not leak upstream"
         );
+    }
+
+    #[test]
+    fn client_reserved_key_does_not_duplicate() {
+        // A client-sent `stream_options` must not collide with the one we set.
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "stream_options".to_string(),
+            serde_json::json!({"include_usage": false}),
+        );
+        let req = ChatCompletionRequest {
+            model: "m".to_string(),
+            messages: vec![],
+            stream: None,
+            temperature: None,
+            max_tokens: None,
+            top_p: None,
+            stop: None,
+            tools: None,
+            tool_choice: None,
+            system: None,
+            extra_headers: Default::default(),
+            raw_anthropic_body: None,
+            extra,
+        };
+        // Serialising must not panic on a duplicate key, and streaming keeps our value.
+        let json = serde_json::to_value(build_request_body(&req, "m", true)).unwrap();
+        assert_eq!(json["stream_options"]["include_usage"], true);
     }
 
     #[test]

--- a/ferrox/src/providers/openai.rs
+++ b/ferrox/src/providers/openai.rs
@@ -219,6 +219,11 @@ struct OpenAIRequest {
     tools: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<Value>,
+    /// Pass-through for standard OpenAI fields Ferrox doesn't model explicitly
+    /// (response_format, seed, n, logprobs, frequency/presence_penalty, user, …),
+    /// so a transparent proxy forwards them instead of silently dropping them.
+    #[serde(flatten)]
+    extra: std::collections::HashMap<String, Value>,
 }
 
 #[derive(Serialize)]
@@ -276,6 +281,14 @@ fn build_request_body(req: &ChatCompletionRequest, model_id: &str, stream: bool)
         stop,
         tools,
         tool_choice: req.tool_choice.clone(),
+        // Forward client-supplied pass-through fields. Internal `_`-prefixed keys
+        // (e.g. `_anthropic_thinking`) are gateway-private and never sent upstream.
+        extra: req
+            .extra
+            .iter()
+            .filter(|(k, _)| !k.starts_with('_'))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
     }
 }
 
@@ -335,6 +348,42 @@ mod tests {
         assert_eq!(
             adapter.completions_url(),
             "https://api.z.ai/api/paas/v4/chat/completions"
+        );
+    }
+
+    #[test]
+    fn extra_fields_pass_through_but_internal_keys_dropped() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "response_format".to_string(),
+            serde_json::json!({"type":"json_object"}),
+        );
+        extra.insert("seed".to_string(), serde_json::json!(42));
+        extra.insert(
+            "_anthropic_thinking".to_string(),
+            serde_json::json!({"type":"enabled"}),
+        );
+        let req = ChatCompletionRequest {
+            model: "m".to_string(),
+            messages: vec![],
+            stream: None,
+            temperature: None,
+            max_tokens: None,
+            top_p: None,
+            stop: None,
+            tools: None,
+            tool_choice: None,
+            system: None,
+            extra_headers: Default::default(),
+            raw_anthropic_body: None,
+            extra,
+        };
+        let json = serde_json::to_value(build_request_body(&req, "m", false)).unwrap();
+        assert_eq!(json["response_format"]["type"], "json_object");
+        assert_eq!(json["seed"], 42);
+        assert!(
+            json.get("_anthropic_thinking").is_none(),
+            "internal `_`-prefixed keys must not leak upstream"
         );
     }
 


### PR DESCRIPTION
Closes #75

## What
Higher-fidelity translation across several fronts:
- **Transparent request pass-through** — `OpenAIRequest` gains a `#[serde(flatten)] extra`, populated from `req.extra` minus internal `_`-prefixed keys. Standard OpenAI fields Ferrox doesn't model (`response_format`/JSON mode, `seed`, `n`, `logprobs`, `frequency/presence_penalty`, `user`, …) now reach OpenAI-format providers instead of being dropped.
- **stop_reason mapping** — `content_filter` → `refusal` (valid Anthropic reason); any unknown value → `end_turn` instead of leaking a non-spec value strict SDK enums reject.
- **Mid-stream errors** — the OpenAI→Anthropic converter now emits a proper Anthropic `error` SSE event on upstream failure, instead of yielding a raw `Err` that axum turns into a bare connection close with no terminal event.
- **System blocks** — array-form system prompts join with `\n` (not `""`, which glued `"You are"`+`"helpful"`).

## Tests
- `extra_fields_pass_through_but_internal_keys_dropped` — `response_format`/`seed` forwarded; `_anthropic_*` not leaked.
- `finish_reason_unknowns_do_not_leak` + updated the test that codified the old passthrough.
- `mid_stream_error_emits_anthropic_error_event` + updated `stream_surfaces_error_as_error_event`.
- Full suite: 229 passed.

## Deferred (noted, not in this PR)
Response-struct `#[serde(flatten)] extra` for `usage.*_tokens_details`/`service_tier`/choice `logprobs` — needs catch-alls on the response/usage structs (constructor churn) and overlaps the cache-token work already tracked. The reverse-direction (Anthropic-adapter) newer stop_reasons and the non-streaming empty-text nit are also follow-ups. Can split into a follow-up issue if preferred.

## Performance
Request `extra` is a small map built once per request; no hot-path streaming cost. Error path adds one event on failure only.