### PR TITLE
fix: preserve image/multimodal content across adapters (#73)

### DIFF
--- a/ferrox/src/anthropic_types.rs
+++ b/ferrox/src/anthropic_types.rs
@@ -281,14 +281,22 @@ fn anthropic_messages_to_internal(messages: Vec<AnthropicMessage>) -> Vec<ChatMe
 
 /// Expand one Anthropic message (block content) into ≥1 internal messages.
 fn convert_blocks(role: String, blocks: Vec<AnthropicContentBlock>, out: &mut Vec<ChatMessage>) {
-    let mut text_parts: Vec<String> = Vec::new();
+    let mut content_parts: Vec<ContentPart> = Vec::new();
     let mut tool_calls: Vec<ToolCall> = Vec::new();
     let mut tool_results: Vec<(String, String)> = Vec::new();
 
     for block in blocks {
         match block {
             AnthropicContentBlock::Text { text } => {
-                text_parts.push(text);
+                content_parts.push(ContentPart::Text { text });
+            }
+            AnthropicContentBlock::Image { source } => {
+                // Translate to an OpenAI image_url part instead of dropping it.
+                if let Some(url) = anthropic_image_source_to_url(&source) {
+                    content_parts.push(ContentPart::ImageUrl {
+                        image_url: crate::types::ImageUrl { url, detail: None },
+                    });
+                }
             }
             AnthropicContentBlock::ToolUse { id, name, input } => {
                 tool_calls.push(ToolCall {
@@ -307,23 +315,16 @@ fn convert_blocks(role: String, blocks: Vec<AnthropicContentBlock>, out: &mut Ve
             } => {
                 tool_results.push((tool_use_id, tool_result_content_to_string(content)));
             }
-            // Image, document, thinking, and Unknown blocks are dropped;
-            // the downstream provider handles images natively via the
-            // pass-through adapters if needed.
-            AnthropicContentBlock::Image { .. } | AnthropicContentBlock::Unknown => {}
+            // Document/thinking/unknown blocks have no OpenAI equivalent — dropped.
+            AnthropicContentBlock::Unknown => {}
         }
     }
 
     if role == "assistant" {
-        // Assistant turn: combine text + tool_calls into one message.
-        let content = if text_parts.is_empty() {
-            None
-        } else {
-            Some(MessageContent::Text(text_parts.join("")))
-        };
+        // Assistant turn: combine text/image + tool_calls into one message.
         out.push(ChatMessage {
             role,
-            content,
+            content: parts_to_content(content_parts),
             name: None,
             tool_calls: if tool_calls.is_empty() {
                 None
@@ -334,12 +335,11 @@ fn convert_blocks(role: String, blocks: Vec<AnthropicContentBlock>, out: &mut Ve
             reasoning_content: None,
         });
     } else {
-        // User turn: text first, then each tool result as a separate "tool" message.
-        let combined_text = text_parts.join("");
-        if !combined_text.is_empty() {
+        // User turn: content (text + images) first, then each tool result.
+        if let Some(content) = parts_to_content(content_parts) {
             out.push(ChatMessage {
                 role: role.clone(),
-                content: Some(MessageContent::Text(combined_text)),
+                content: Some(content),
                 name: None,
                 tool_calls: None,
                 tool_call_id: None,
@@ -356,6 +356,44 @@ fn convert_blocks(role: String, blocks: Vec<AnthropicContentBlock>, out: &mut Ve
                 reasoning_content: None,
             });
         }
+    }
+}
+
+/// Collapse collected content parts into a message content: a single `Text` when
+/// everything is text (the common case), `Parts` when any image is present, or
+/// `None` when empty.
+fn parts_to_content(parts: Vec<ContentPart>) -> Option<MessageContent> {
+    if parts.is_empty() {
+        return None;
+    }
+    if parts.iter().all(|p| matches!(p, ContentPart::Text { .. })) {
+        let text = parts
+            .into_iter()
+            .filter_map(|p| match p {
+                ContentPart::Text { text } => Some(text),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        return Some(MessageContent::Text(text));
+    }
+    Some(MessageContent::Parts(parts))
+}
+
+/// Convert an Anthropic image `source` object to an OpenAI `image_url` URL.
+/// `base64` sources become a `data:` URL; `url` sources pass through.
+fn anthropic_image_source_to_url(source: &serde_json::Value) -> Option<String> {
+    match source.get("type").and_then(|t| t.as_str()) {
+        Some("base64") => {
+            let media = source
+                .get("media_type")
+                .and_then(|m| m.as_str())
+                .unwrap_or("image/jpeg");
+            let data = source.get("data").and_then(|d| d.as_str())?;
+            Some(format!("data:{media};base64,{data}"))
+        }
+        Some("url") => source.get("url").and_then(|u| u.as_str()).map(String::from),
+        _ => None,
     }
 }
 
@@ -1187,6 +1225,39 @@ mod tests {
             r#"{"type": "document", "source": {"type": "url", "url": "https://example.com"}}"#;
         let block: AnthropicContentBlock = serde_json::from_str(block_json).unwrap();
         assert!(matches!(block, AnthropicContentBlock::Unknown));
+    }
+
+    #[test]
+    fn image_block_is_preserved_as_image_url_part() {
+        // Regression: image blocks were dropped, so providers hallucinated.
+        let json = r#"{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[
+            {"type":"text","text":"what is this?"},
+            {"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAAA"}}
+        ]}]}"#;
+        let req: AnthropicMessagesRequest = serde_json::from_str(json).unwrap();
+        let internal = to_chat_completion_request(req);
+        match internal.messages[0].content.as_ref().unwrap() {
+            MessageContent::Parts(parts) => {
+                assert!(
+                    parts
+                        .iter()
+                        .any(|p| matches!(p, ContentPart::ImageUrl { image_url }
+                        if image_url.url == "data:image/png;base64,AAAA")),
+                    "image preserved as a data URL"
+                );
+                assert!(parts.iter().any(|p| matches!(p, ContentPart::Text { .. })));
+            }
+            other => panic!("expected multimodal Parts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn url_image_source_passes_through() {
+        let src = serde_json::json!({"type":"url","url":"https://x/i.png"});
+        assert_eq!(
+            anthropic_image_source_to_url(&src).as_deref(),
+            Some("https://x/i.png")
+        );
     }
 
     // ── to_anthropic_response ─────────────────────────────────────────────────

--- a/ferrox/src/providers/anthropic.rs
+++ b/ferrox/src/providers/anthropic.rs
@@ -214,10 +214,30 @@ enum AnthropicPart {
 }
 
 #[derive(Serialize, Clone)]
-struct AnthropicImageSource {
-    #[serde(rename = "type")]
-    source_type: String,
-    url: String,
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AnthropicImageSource {
+    /// Inline base64 image data. Required for `data:` URIs — sending those as a
+    /// `url` source is rejected by api.anthropic.com.
+    Base64 { media_type: String, data: String },
+    /// A fetchable http(s) URL.
+    Url { url: String },
+}
+
+/// Build an Anthropic image source from an OpenAI `image_url` URL, splitting
+/// `data:<media>;base64,<data>` into a base64 source and passing URLs through.
+fn image_url_to_source(url: &str) -> AnthropicImageSource {
+    if let Some(rest) = url.strip_prefix("data:") {
+        if let Some((header, data)) = rest.split_once(',') {
+            let media_type = header.split(';').next().unwrap_or("image/jpeg").to_string();
+            return AnthropicImageSource::Base64 {
+                media_type,
+                data: data.to_string(),
+            };
+        }
+    }
+    AnthropicImageSource::Url {
+        url: url.to_string(),
+    }
 }
 
 #[derive(Serialize)]
@@ -429,10 +449,7 @@ fn convert_message(msg: &ChatMessage) -> AnthropicMessage {
                     .map(|p| match p {
                         ContentPart::Text { text } => AnthropicPart::Text { text: text.clone() },
                         ContentPart::ImageUrl { image_url } => AnthropicPart::Image {
-                            source: AnthropicImageSource {
-                                source_type: "url".to_string(),
-                                url: image_url.url.clone(),
-                            },
+                            source: image_url_to_source(&image_url.url),
                         },
                     })
                     .collect();
@@ -633,5 +650,23 @@ mod tests {
         assert!(
             matches!(&out.choices[0].message.content, Some(crate::types::MessageContent::Text(t)) if t == "hi")
         );
+    }
+    #[test]
+    fn data_url_image_becomes_base64_source() {
+        match image_url_to_source("data:image/png;base64,QUJD") {
+            AnthropicImageSource::Base64 { media_type, data } => {
+                assert_eq!(media_type, "image/png");
+                assert_eq!(data, "QUJD");
+            }
+            _ => panic!("data: URL must become a base64 source"),
+        }
+    }
+
+    #[test]
+    fn http_url_image_stays_url_source() {
+        assert!(matches!(
+            image_url_to_source("https://x/i.png"),
+            AnthropicImageSource::Url { .. }
+        ));
     }
 }

--- a/ferrox/src/providers/bedrock.rs
+++ b/ferrox/src/providers/bedrock.rs
@@ -265,21 +265,41 @@ fn bedrock_message(m: &ChatMessage) -> Value {
 
     let content = match &m.content {
         Some(MessageContent::Text(t)) => Value::String(t.clone()),
-        // Multi-part (image) content is handled in the multimodal work (#73);
-        // fall back to concatenated text here.
-        Some(MessageContent::Parts(parts)) => Value::String(
+        // Multi-part content → Anthropic content-block array (text + image).
+        Some(MessageContent::Parts(parts)) => Value::Array(
             parts
                 .iter()
-                .filter_map(|p| match p {
-                    crate::types::ContentPart::Text { text } => Some(text.as_str()),
-                    _ => None,
+                .map(|p| match p {
+                    crate::types::ContentPart::Text { text } => {
+                        serde_json::json!({"type": "text", "text": text})
+                    }
+                    crate::types::ContentPart::ImageUrl { image_url } => {
+                        anthropic_image_block(&image_url.url)
+                    }
                 })
-                .collect::<Vec<_>>()
-                .join(""),
+                .collect(),
         ),
         None => Value::String(String::new()),
     };
     serde_json::json!({ "role": role, "content": content })
+}
+
+/// Build an Anthropic `image` content block from an OpenAI image URL
+/// (`data:` → base64 source; otherwise a `url` source).
+fn anthropic_image_block(url: &str) -> Value {
+    if let Some(rest) = url.strip_prefix("data:") {
+        if let Some((header, data)) = rest.split_once(',') {
+            let media_type = header.split(';').next().unwrap_or("image/jpeg");
+            return serde_json::json!({
+                "type": "image",
+                "source": {"type": "base64", "media_type": media_type, "data": data},
+            });
+        }
+    }
+    serde_json::json!({
+        "type": "image",
+        "source": {"type": "url", "url": url},
+    })
 }
 
 /// Map an OpenAI `tool_choice` to an Anthropic `tool_choice` object.
@@ -499,5 +519,33 @@ mod tests {
         assert_eq!(tc.function.name, "get_weather");
         assert!(tc.function.arguments.contains("NYC"));
         assert_eq!(out.choices[0].finish_reason.as_deref(), Some("tool_calls"));
+    }
+    #[test]
+    fn image_part_becomes_anthropic_image_block() {
+        let m = ChatMessage {
+            role: "user".into(),
+            content: Some(MessageContent::Parts(vec![
+                crate::types::ContentPart::Text {
+                    text: "look".into(),
+                },
+                crate::types::ContentPart::ImageUrl {
+                    image_url: crate::types::ImageUrl {
+                        url: "data:image/png;base64,QUJD".into(),
+                        detail: None,
+                    },
+                },
+            ])),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+        };
+        let v = bedrock_message(&m);
+        let blocks = v["content"].as_array().unwrap();
+        assert_eq!(blocks[0]["type"], "text");
+        assert_eq!(blocks[1]["type"], "image");
+        assert_eq!(blocks[1]["source"]["type"], "base64");
+        assert_eq!(blocks[1]["source"]["media_type"], "image/png");
+        assert_eq!(blocks[1]["source"]["data"], "QUJD");
     }
 }


### PR DESCRIPTION
Closes #73

## What
Image content was dropped or mangled on nearly every path (confirmed live: a real image sent to `glm-5.2` produced a hallucinated answer). Now preserved end-to-end.

- **Ingress converter** (`anthropic_types.rs`) — Anthropic `image` blocks (both `base64` and `url` sources) become `ContentPart::ImageUrl` instead of being dropped; base64 → a `data:` URL. User/assistant messages carry `MessageContent::Parts` when an image is present (text-only still collapses to `Text`).
- **Anthropic adapter** (`providers/anthropic.rs`) — `AnthropicImageSource` is now an enum; a `data:` URI is split into a **base64** source (previously sent as a `url` source, which api.anthropic.com rejects); real URLs pass through.
- **Bedrock adapter** (`providers/bedrock.rs`) — multi-part content becomes an Anthropic content-block array (text + `image` blocks) instead of being collapsed to an empty/plain string.
- **OpenAI/Kimi/GLM** already forward `image_url` parts natively (they serialise the message), so the ingress fix alone makes them see images.

## Tests (5 new, 241 total)
Ingress image block → `image_url` data-URL part (regression for the drop); url-source passthrough; Anthropic `data:`→base64 source and http→url source; Bedrock image part → base64 `image` block.

## Deferred (noted)
- **Gemini http(s)-URL images** — Gemini needs `fileData`/inline bytes (it can't fetch an arbitrary URL), so http image URLs need a fetch-and-inline step (a small async change). `data:` images already work (→ `inline_data`).
- **Images inside `tool_result`** and **`document` blocks** — lower-frequency; can follow up.

## Performance
Image handling is per-message part mapping; base64 payloads are moved/borrowed, not re-encoded. No hot-path streaming cost.