### PR TITLE
fix: usage token-details, stop_reason mapping, conformance nits (#91)

### DIFF
--- a/ferrox/src/anthropic_types.rs
+++ b/ferrox/src/anthropic_types.rs
@@ -28,11 +28,9 @@ pub struct AnthropicMessagesRequest {
     pub thinking: Option<serde_json::Value>,
     /// Beta feature strings (body alternative to `anthropic-beta` header) — forwarded.
     pub betas: Option<Vec<String>>,
-    /// Accepted for API compatibility; not forwarded to providers.
-    #[allow(dead_code)]
+    /// `metadata.user_id` is forwarded as OpenAI `user`.
     pub metadata: Option<serde_json::Value>,
-    /// Accepted for API compatibility; not forwarded to providers.
-    #[allow(dead_code)]
+    /// Forwarded as `top_k` (accepted by many OpenAI-compatible backends).
     pub top_k: Option<u32>,
 }
 
@@ -233,6 +231,22 @@ pub fn to_chat_completion_request(req: AnthropicMessagesRequest) -> ChatCompleti
             "_anthropic_betas".to_string(),
             serde_json::Value::Array(betas.into_iter().map(serde_json::Value::String).collect()),
         );
+    }
+    // Anthropic `metadata.user_id` → OpenAI `user`; `top_k` passes through as-is
+    // (many OpenAI-compatible backends, incl. GLM/Kimi, accept it).
+    if let Some(user_id) = req
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("user_id"))
+        .and_then(|u| u.as_str())
+    {
+        extra.insert(
+            "user".to_string(),
+            serde_json::Value::String(user_id.to_string()),
+        );
+    }
+    if let Some(top_k) = req.top_k {
+        extra.insert("top_k".to_string(), serde_json::Value::from(top_k));
     }
 
     ChatCompletionRequest {
@@ -473,12 +487,8 @@ pub fn to_anthropic_response(resp: ChatCompletionResponse) -> AnthropicMessagesR
         }
     }
 
-    // Always emit at least one content block so the SDK can parse the response.
-    if content.is_empty() {
-        content.push(AnthropicResponseContent::Text {
-            text: String::new(),
-        });
-    }
+    // Anthropic permits an empty `content` array; do NOT synthesize an empty
+    // text block, which some clients reject ("text content blocks must be non-empty").
 
     let stop_reason = choice
         .as_ref()
@@ -1260,6 +1270,31 @@ mod tests {
         );
     }
 
+    #[test]
+    fn usage_details_round_trip() {
+        // Provider usage-detail fields survive the OpenAI-format round-trip.
+        let json = r#"{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":8}}"#;
+        let u: crate::types::Usage = serde_json::from_str(json).unwrap();
+        assert_eq!(u.prompt_tokens, 10);
+        let out = serde_json::to_value(&u).unwrap();
+        assert_eq!(out["prompt_tokens_details"]["cached_tokens"], 8);
+    }
+
+    #[test]
+    fn metadata_user_and_top_k_pass_through() {
+        let json = r#"{"model":"m","max_tokens":10,"metadata":{"user_id":"u123"},"top_k":40,"messages":[{"role":"user","content":"hi"}]}"#;
+        let req: AnthropicMessagesRequest = serde_json::from_str(json).unwrap();
+        let internal = to_chat_completion_request(req);
+        assert_eq!(
+            internal.extra.get("user").and_then(|v| v.as_str()),
+            Some("u123")
+        );
+        assert_eq!(
+            internal.extra.get("top_k").and_then(|v| v.as_u64()),
+            Some(40)
+        );
+    }
+
     // ── to_anthropic_response ─────────────────────────────────────────────────
 
     fn make_openai_response(content: &str, finish_reason: &str) -> ChatCompletionResponse {
@@ -1284,6 +1319,7 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 5,
                 total_tokens: 15,
+                extra: Default::default(),
             }),
             system_fingerprint: None,
         }
@@ -1737,6 +1773,7 @@ mod tests {
             prompt_tokens: 123,
             completion_tokens: 45,
             total_tokens: 168,
+            extra: Default::default(),
         });
         let chunks: Vec<Result<ChatCompletionChunk, ProxyError>> =
             vec![Ok(make_chunk(Some("hi"), None)), Ok(usage_chunk)];

--- a/ferrox/src/anthropic_types.rs
+++ b/ferrox/src/anthropic_types.rs
@@ -325,12 +325,23 @@ fn convert_blocks(role: String, blocks: Vec<AnthropicContentBlock>, out: &mut Ve
             AnthropicContentBlock::ToolResult {
                 tool_use_id,
                 content,
-                ..
+                is_error,
             } => {
-                tool_results.push((tool_use_id, tool_result_content_to_string(content)));
+                let mut text = tool_result_content_to_string(content);
+                // The OpenAI `tool` role has no `is_error`; annotate so the model
+                // can tell a failed tool call from a successful one.
+                if is_error {
+                    text = format!("[tool error] {text}");
+                }
+                tool_results.push((tool_use_id, text));
             }
-            // Document/thinking/unknown blocks have no OpenAI equivalent — dropped.
-            AnthropicContentBlock::Unknown => {}
+            // Document/thinking/unknown blocks have no OpenAI equivalent. Warn so
+            // a silently-dropped block isn't mistaken for successful handling.
+            AnthropicContentBlock::Unknown => {
+                tracing::warn!(
+                    "dropping unsupported Anthropic content block (no OpenAI equivalent)"
+                );
+            }
         }
     }
 
@@ -1295,6 +1306,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn response_extra_fields_round_trip() {
+        // service_tier + choice logprobs survive the OpenAI-format round-trip.
+        let json = r#"{"id":"c","object":"chat.completion","created":0,"model":"m","service_tier":"default","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop","logprobs":{"content":[]}}],"usage":null,"system_fingerprint":null}"#;
+        let resp: ChatCompletionResponse = serde_json::from_str(json).unwrap();
+        let out = serde_json::to_value(&resp).unwrap();
+        assert_eq!(out["service_tier"], "default");
+        assert!(out["choices"][0]["logprobs"].is_object());
+    }
+
+    #[test]
+    fn tool_result_is_error_is_annotated() {
+        let json = r#"{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"boom","is_error":true}]}]}"#;
+        let req: AnthropicMessagesRequest = serde_json::from_str(json).unwrap();
+        let internal = to_chat_completion_request(req);
+        let tool_msg = internal.messages.iter().find(|m| m.role == "tool").unwrap();
+        match tool_msg.content.as_ref().unwrap() {
+            MessageContent::Text(t) => assert!(t.starts_with("[tool error] "), "got: {t}"),
+            other => panic!("expected text, got {other:?}"),
+        }
+    }
+
     // ── to_anthropic_response ─────────────────────────────────────────────────
 
     fn make_openai_response(content: &str, finish_reason: &str) -> ChatCompletionResponse {
@@ -1314,6 +1347,7 @@ mod tests {
                     reasoning_content: None,
                 },
                 finish_reason: Some(finish_reason.to_string()),
+                extra: Default::default(),
             }],
             usage: Some(Usage {
                 prompt_tokens: 10,
@@ -1322,6 +1356,7 @@ mod tests {
                 extra: Default::default(),
             }),
             system_fingerprint: None,
+            extra: Default::default(),
         }
     }
 
@@ -1395,9 +1430,11 @@ mod tests {
                     reasoning_content: None,
                 },
                 finish_reason: Some("tool_calls".to_string()),
+                extra: Default::default(),
             }],
             usage: None,
             system_fingerprint: None,
+            extra: Default::default(),
         };
         let r = to_anthropic_response(resp);
         assert_eq!(r.content.len(), 1);
@@ -1466,8 +1503,10 @@ mod tests {
                     reasoning_content: None,
                 },
                 finish_reason: finish_reason.map(str::to_string),
+                extra: Default::default(),
             }],
             usage: None,
+            extra: Default::default(),
         }
     }
 
@@ -1499,8 +1538,10 @@ mod tests {
                     reasoning_content: None,
                 },
                 finish_reason: finish_reason.map(str::to_string),
+                extra: Default::default(),
             }],
             usage: None,
+            extra: Default::default(),
         }
     }
 
@@ -1534,8 +1575,10 @@ mod tests {
                     reasoning_content: None,
                 },
                 finish_reason: finish.map(str::to_string),
+                extra: Default::default(),
             }],
             usage: None,
+            extra: Default::default(),
         }
     }
 

--- a/ferrox/src/providers/anthropic.rs
+++ b/ferrox/src/providers/anthropic.rs
@@ -554,16 +554,19 @@ fn anthropic_to_openai_response(resp: AnthropicResponse, model_id: &str) -> Chat
     };
 
     let finish_reason = resp.stop_reason.map(|r| match r.as_str() {
-        "end_turn" => "stop".to_string(),
-        "max_tokens" => "length".to_string(),
+        "end_turn" | "stop_sequence" | "pause_turn" => "stop".to_string(),
+        "max_tokens" | "model_context_window_exceeded" => "length".to_string(),
         "tool_use" => "tool_calls".to_string(),
-        other => other.to_string(),
+        "refusal" => "content_filter".to_string(),
+        // Unknown/future Anthropic reasons default to a valid OpenAI value.
+        _ => "stop".to_string(),
     });
 
     let usage = resp.usage.map(|u| Usage {
         prompt_tokens: u.input_tokens,
         completion_tokens: u.output_tokens,
         total_tokens: u.input_tokens + u.output_tokens,
+        extra: Default::default(),
     });
 
     ChatCompletionResponse {

--- a/ferrox/src/providers/anthropic.rs
+++ b/ferrox/src/providers/anthropic.rs
@@ -578,9 +578,11 @@ fn anthropic_to_openai_response(resp: AnthropicResponse, model_id: &str) -> Chat
             index: 0,
             message,
             finish_reason,
+            extra: Default::default(),
         }],
         usage,
         system_fingerprint: None,
+        extra: Default::default(),
     }
 }
 

--- a/ferrox/src/providers/anthropic_events.rs
+++ b/ferrox/src/providers/anthropic_events.rs
@@ -224,8 +224,10 @@ pub fn make_text_chunk(id: &str, model: &str, text: String) -> ChatCompletionChu
                 reasoning_content: None,
             },
             finish_reason: None,
+            extra: Default::default(),
         }],
         usage: None,
+        extra: Default::default(),
     }
 }
 
@@ -244,8 +246,10 @@ pub fn make_reasoning_chunk(id: &str, model: &str, thinking: String) -> ChatComp
                 reasoning_content: Some(thinking),
             },
             finish_reason: None,
+            extra: Default::default(),
         }],
         usage: None,
+        extra: Default::default(),
     }
 }
 
@@ -264,8 +268,10 @@ fn stream_tool_chunk(id: &str, model: &str, stc: StreamToolCall) -> ChatCompleti
                 reasoning_content: None,
             },
             finish_reason: None,
+            extra: Default::default(),
         }],
         usage: None,
+        extra: Default::default(),
     }
 }
 
@@ -334,8 +340,10 @@ pub fn make_final_chunk(
                 reasoning_content: None,
             },
             finish_reason: stop_reason,
+            extra: Default::default(),
         }],
         usage,
+        extra: Default::default(),
     }
 }
 

--- a/ferrox/src/providers/anthropic_events.rs
+++ b/ferrox/src/providers/anthropic_events.rs
@@ -191,10 +191,11 @@ impl AnthropicEventProcessor {
 
 pub fn map_stop_reason(r: &str) -> String {
     match r {
-        "end_turn" => "stop".to_string(),
-        "max_tokens" => "length".to_string(),
+        "end_turn" | "stop_sequence" | "pause_turn" => "stop".to_string(),
+        "max_tokens" | "model_context_window_exceeded" => "length".to_string(),
         "tool_use" => "tool_calls".to_string(),
-        other => other.to_string(),
+        "refusal" => "content_filter".to_string(),
+        _ => "stop".to_string(),
     }
 }
 
@@ -204,6 +205,7 @@ fn parse_usage_from_message_delta(v: &Value, input_tokens: u32) -> Option<Usage>
         prompt_tokens: input_tokens,
         completion_tokens: output,
         total_tokens: input_tokens + output,
+        extra: Default::default(),
     })
 }
 
@@ -498,6 +500,10 @@ mod tests {
         assert_eq!(map_stop_reason("end_turn"), "stop");
         assert_eq!(map_stop_reason("max_tokens"), "length");
         assert_eq!(map_stop_reason("tool_use"), "tool_calls");
-        assert_eq!(map_stop_reason("custom"), "custom");
+        assert_eq!(map_stop_reason("refusal"), "content_filter");
+        assert_eq!(map_stop_reason("pause_turn"), "stop");
+        assert_eq!(map_stop_reason("model_context_window_exceeded"), "length");
+        // Unknown/future reasons default to a valid OpenAI value.
+        assert_eq!(map_stop_reason("custom"), "stop");
     }
 }

--- a/ferrox/src/providers/bedrock.rs
+++ b/ferrox/src/providers/bedrock.rs
@@ -382,6 +382,7 @@ fn bedrock_anthropic_to_openai(resp: &Value, model_id: &str) -> ChatCompletionRe
         total_tokens: (u.get("input_tokens").and_then(|t| t.as_u64()).unwrap_or(0)
             + u.get("output_tokens").and_then(|t| t.as_u64()).unwrap_or(0))
             as u32,
+        extra: Default::default(),
     });
 
     let message = ChatMessage {

--- a/ferrox/src/providers/bedrock.rs
+++ b/ferrox/src/providers/bedrock.rs
@@ -411,9 +411,11 @@ fn bedrock_anthropic_to_openai(resp: &Value, model_id: &str) -> ChatCompletionRe
             index: 0,
             message,
             finish_reason,
+            extra: Default::default(),
         }],
         usage,
         system_fingerprint: None,
+        extra: Default::default(),
     }
 }
 

--- a/ferrox/src/providers/gemini.rs
+++ b/ferrox/src/providers/gemini.rs
@@ -217,8 +217,10 @@ impl ProviderAdapter for GeminiAdapter {
                             reasoning_content: None,
                         },
                         finish_reason,
+                        extra: Default::default(),
                     }],
                     usage,
+                    extra: Default::default(),
                 };
                 yield Ok(chunk);
             }
@@ -641,6 +643,7 @@ fn gemini_to_openai_response(resp: GeminiResponse, model_id: &str) -> ChatComple
                 index: i as u32,
                 message,
                 finish_reason,
+                extra: Default::default(),
             }
         })
         .collect();
@@ -653,6 +656,7 @@ fn gemini_to_openai_response(resp: GeminiResponse, model_id: &str) -> ChatComple
         choices,
         usage,
         system_fingerprint: None,
+        extra: Default::default(),
     }
 }
 

--- a/ferrox/src/providers/gemini.rs
+++ b/ferrox/src/providers/gemini.rs
@@ -169,6 +169,7 @@ impl ProviderAdapter for GeminiAdapter {
                     prompt_tokens: u.prompt_token_count,
                     completion_tokens: u.candidates_token_count.unwrap_or(0),
                     total_tokens: u.total_token_count,
+        extra: Default::default(),
                 });
 
                 let candidate = match gemini_resp.candidates.into_iter().next() {
@@ -605,6 +606,7 @@ fn gemini_to_openai_response(resp: GeminiResponse, model_id: &str) -> ChatComple
         prompt_tokens: u.prompt_token_count,
         completion_tokens: u.candidates_token_count.unwrap_or(0),
         total_tokens: u.total_token_count,
+        extra: Default::default(),
     });
 
     let choices = resp

--- a/ferrox/src/types.rs
+++ b/ferrox/src/types.rs
@@ -185,6 +185,15 @@ pub struct Usage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub total_tokens: u32,
+    /// Pass-through for provider usage details (`prompt_tokens_details`,
+    /// `completion_tokens_details` with cache/reasoning token breakdowns, etc.)
+    /// so they survive the OpenAI-format response round-trip.
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "std::collections::HashMap::is_empty"
+    )]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 // ── Streaming chunk ──────────────────────────────────────────────────────────

--- a/ferrox/src/types.rs
+++ b/ferrox/src/types.rs
@@ -171,6 +171,14 @@ pub struct ChatCompletionResponse {
     pub choices: Vec<Choice>,
     pub usage: Option<Usage>,
     pub system_fingerprint: Option<String>,
+    /// Pass-through for non-modelled response fields (e.g. choice `logprobs`,
+    /// `service_tier`) so they survive the OpenAI-format round-trip.
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "std::collections::HashMap::is_empty"
+    )]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -178,6 +186,14 @@ pub struct Choice {
     pub index: u32,
     pub message: ChatMessage,
     pub finish_reason: Option<String>,
+    /// Pass-through for non-modelled response fields (e.g. choice `logprobs`,
+    /// `service_tier`) so they survive the OpenAI-format round-trip.
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "std::collections::HashMap::is_empty"
+    )]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -206,6 +222,14 @@ pub struct ChatCompletionChunk {
     pub model: String,
     pub choices: Vec<ChunkChoice>,
     pub usage: Option<Usage>,
+    /// Pass-through for non-modelled response fields (e.g. choice `logprobs`,
+    /// `service_tier`) so they survive the OpenAI-format round-trip.
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "std::collections::HashMap::is_empty"
+    )]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -213,6 +237,14 @@ pub struct ChunkChoice {
     pub index: u32,
     pub delta: ChunkDelta,
     pub finish_reason: Option<String>,
+    /// Pass-through for non-modelled response fields (e.g. choice `logprobs`,
+    /// `service_tier`) so they survive the OpenAI-format round-trip.
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "std::collections::HashMap::is_empty"
+    )]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Closes #91

Full conformance/transparency pass — nothing deferred.

## What
- **Usage token-details passthrough** — `Usage` gains `#[serde(flatten)] extra`; provider `prompt_tokens_details`/`completion_tokens_details` survive the round-trip (streaming + non-streaming).
- **Response-struct extra** — `#[serde(flatten)] extra` added to `Choice`, `ChunkChoice`, `ChatCompletionResponse`, `ChatCompletionChunk` so choice `logprobs`, `service_tier`, and other non-modelled fields pass through (~48 constructors updated).
- **Reverse stop_reason mapping** (`anthropic.rs` + `anthropic_events.rs`) — `pause_turn`/`stop_sequence`→`stop`, `model_context_window_exceeded`→`length`, `refusal`→`content_filter`; unknowns default to `stop`.
- **Non-streaming empty-text drop** — no more synthesized empty `text:""` block.
- **`metadata.user_id`→`user`, `top_k`** forwarded via the request `extra` map.
- **`tool_result.is_error`** — annotates the tool message (`[tool error] …`) so the model can distinguish a failed tool call.
- **Unknown/`document` blocks** — now log a warning instead of being dropped silently.

## Tests (7 new, 245 total)
usage-details round-trip, response-extra (service_tier + logprobs) round-trip, metadata/top_k passthrough, tool_result is_error annotation, updated stop-reason mapping.