### PR TITLE
fix: Gemini remote-image inlining + multimodal edge handling (#95)

### DIFF
--- a/ferrox/src/anthropic_types.rs
+++ b/ferrox/src/anthropic_types.rs
@@ -434,12 +434,19 @@ fn tool_result_content_to_string(v: Option<serde_json::Value>) -> String {
         Some(serde_json::Value::String(s)) => s,
         Some(serde_json::Value::Array(arr)) => arr
             .iter()
-            .filter_map(|item| {
-                if item.get("type").and_then(|t| t.as_str()) == Some("text") {
-                    item.get("text")
-                        .and_then(|t| t.as_str())
-                        .map(str::to_string)
-                } else {
+            .filter_map(|item| match item.get("type").and_then(|t| t.as_str()) {
+                Some("text") => item
+                    .get("text")
+                    .and_then(|t| t.as_str())
+                    .map(str::to_string),
+                other => {
+                    // OpenAI `tool` role messages are text-only, so non-text tool
+                    // result blocks (e.g. images) can't be represented — warn
+                    // instead of dropping silently.
+                    tracing::warn!(
+                        block = other.unwrap_or("unknown"),
+                        "dropping non-text tool_result block (OpenAI tool messages are text-only)"
+                    );
                     None
                 }
             })
@@ -1314,6 +1321,20 @@ mod tests {
         let out = serde_json::to_value(&resp).unwrap();
         assert_eq!(out["service_tier"], "default");
         assert!(out["choices"][0]["logprobs"].is_object());
+    }
+
+    #[test]
+    fn tool_result_non_text_dropped_text_kept() {
+        // A tool_result with text + image: text preserved, image dropped (OpenAI
+        // tool messages are text-only).
+        let json = r#"{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"text","text":"see this:"},{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAAA"}}]}]}]}"#;
+        let req: AnthropicMessagesRequest = serde_json::from_str(json).unwrap();
+        let internal = to_chat_completion_request(req);
+        let tool_msg = internal.messages.iter().find(|m| m.role == "tool").unwrap();
+        match tool_msg.content.as_ref().unwrap() {
+            MessageContent::Text(t) => assert_eq!(t, "see this:"),
+            other => panic!("expected text, got {other:?}"),
+        }
     }
 
     #[test]

--- a/ferrox/src/providers/gemini.rs
+++ b/ferrox/src/providers/gemini.rs
@@ -54,6 +54,49 @@ impl GeminiAdapter {
     }
 }
 
+impl GeminiAdapter {
+    /// Gemini can't fetch an arbitrary image URL, so download any http(s) image
+    /// parts and inline them as `data:` URLs (which `convert_message` turns into
+    /// `inline_data`). A fetch failure leaves the URL untouched.
+    async fn inline_remote_images(&self, req: &ChatCompletionRequest) -> ChatCompletionRequest {
+        let mut resolved = req.clone();
+        for msg in &mut resolved.messages {
+            if let Some(MessageContent::Parts(parts)) = &mut msg.content {
+                for part in parts.iter_mut() {
+                    if let ContentPart::ImageUrl { image_url } = part {
+                        if !image_url.url.starts_with("data:") {
+                            if let Some(data_url) =
+                                self.fetch_image_as_data_url(&image_url.url).await
+                            {
+                                image_url.url = data_url;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        resolved
+    }
+
+    async fn fetch_image_as_data_url(&self, url: &str) -> Option<String> {
+        let resp = self.client.get(url).send().await.ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+        let mime = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.split(';').next())
+            .unwrap_or("image/jpeg")
+            .to_string();
+        let bytes = resp.bytes().await.ok()?;
+        use base64::Engine;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        Some(format!("data:{mime};base64,{b64}"))
+    }
+}
+
 #[async_trait]
 impl ProviderAdapter for GeminiAdapter {
     fn name(&self) -> &str {
@@ -65,7 +108,8 @@ impl ProviderAdapter for GeminiAdapter {
         req: &ChatCompletionRequest,
         model_id: &str,
     ) -> Result<ChatCompletionResponse, ProxyError> {
-        let body = build_request_body(req);
+        let req = self.inline_remote_images(req).await;
+        let body = build_request_body(&req);
         let url = format!(
             "{}/v1beta/models/{}:generateContent?key={}",
             self.base_url, model_id, self.api_key
@@ -105,7 +149,8 @@ impl ProviderAdapter for GeminiAdapter {
         req: &ChatCompletionRequest,
         model_id: &str,
     ) -> Result<ProviderStream, ProxyError> {
-        let body = build_request_body(req);
+        let req = self.inline_remote_images(req).await;
+        let body = build_request_body(&req);
         let url = format!(
             "{}/v1beta/models/{}:streamGenerateContent?key={}&alt=sse",
             self.base_url, model_id, self.api_key
@@ -663,7 +708,54 @@ fn gemini_to_openai_response(resp: GeminiResponse, model_id: &str) -> ChatComple
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{Tool, ToolFunction};
+    use crate::config::{DefaultsConfig, ProviderConfig, ProviderType};
+    use crate::types::{ImageUrl, Tool, ToolFunction};
+
+    fn adapter() -> GeminiAdapter {
+        GeminiAdapter::new(
+            &ProviderConfig {
+                name: "g".into(),
+                provider_type: ProviderType::Gemini,
+                api_key: Some("k".into()),
+                base_url: None,
+                region: None,
+                timeouts: None,
+                retry: None,
+                circuit_breaker: None,
+            },
+            &DefaultsConfig::default(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn data_url_images_are_not_refetched() {
+        // A data: image must be left untouched (no network fetch).
+        let a = adapter();
+        let msg = ChatMessage {
+            role: "user".into(),
+            content: Some(MessageContent::Parts(vec![ContentPart::ImageUrl {
+                image_url: ImageUrl {
+                    url: "data:image/png;base64,QUJD".into(),
+                    detail: None,
+                },
+            }])),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+        };
+        let resolved = a.inline_remote_images(&req(vec![msg], None)).await;
+        if let Some(MessageContent::Parts(parts)) = &resolved.messages[0].content {
+            if let ContentPart::ImageUrl { image_url } = &parts[0] {
+                assert_eq!(image_url.url, "data:image/png;base64,QUJD");
+            } else {
+                panic!("expected image part");
+            }
+        } else {
+            panic!("expected parts");
+        }
+    }
 
     fn req(messages: Vec<ChatMessage>, tool_choice: Option<Value>) -> ChatCompletionRequest {
         ChatCompletionRequest {

--- a/ferrox/src/providers/gemini.rs
+++ b/ferrox/src/providers/gemini.rs
@@ -79,7 +79,30 @@ impl GeminiAdapter {
     }
 
     async fn fetch_image_as_data_url(&self, url: &str) -> Option<String> {
-        let resp = self.client.get(url).send().await.ok()?;
+        // SSRF guard: only http(s), and refuse hosts that resolve to a non-public
+        // address (loopback/private/link-local incl. cloud-metadata 169.254.169.254).
+        let parsed = reqwest::Url::parse(url).ok()?;
+        if !matches!(parsed.scheme(), "http" | "https") {
+            return None;
+        }
+        let host = parsed.host_str()?;
+        let port = parsed.port_or_known_default().unwrap_or(443);
+        let mut resolved_any = false;
+        for addr in tokio::net::lookup_host((host, port)).await.ok()? {
+            resolved_any = true;
+            if !is_public_ip(&addr.ip()) {
+                tracing::warn!(
+                    %host,
+                    "refusing to fetch image from a non-public address (SSRF guard)"
+                );
+                return None;
+            }
+        }
+        if !resolved_any {
+            return None;
+        }
+
+        let resp = self.client.get(parsed).send().await.ok()?;
         if !resp.status().is_success() {
             return None;
         }
@@ -91,9 +114,44 @@ impl GeminiAdapter {
             .unwrap_or("image/jpeg")
             .to_string();
         let bytes = resp.bytes().await.ok()?;
+        // Cap the download to bound memory (20 MiB).
+        if bytes.len() > 20 * 1024 * 1024 {
+            tracing::warn!(len = bytes.len(), "remote image exceeds size cap; skipping");
+            return None;
+        }
         use base64::Engine;
         let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
         Some(format!("data:{mime};base64,{b64}"))
+    }
+}
+
+/// Whether an IP is a public (non-internal) address — used to block SSRF to
+/// loopback, private, link-local (incl. cloud metadata), and unspecified ranges.
+fn is_public_ip(ip: &std::net::IpAddr) -> bool {
+    use std::net::IpAddr;
+    match ip {
+        IpAddr::V4(v4) => {
+            !(v4.is_private()
+                || v4.is_loopback()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_documentation()
+                || v4.octets()[0] == 0)
+        }
+        IpAddr::V6(v6) => {
+            if v6.is_loopback() || v6.is_unspecified() || v6.is_multicast() {
+                return false;
+            }
+            // IPv4-mapped (::ffff:a.b.c.d) → check the embedded v4.
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_public_ip(&IpAddr::V4(v4));
+            }
+            let seg0 = v6.segments()[0];
+            let unique_local = seg0 & 0xfe00 == 0xfc00; // fc00::/7
+            let link_local = seg0 & 0xffc0 == 0xfe80; // fe80::/10
+            !(unique_local || link_local)
+        }
     }
 }
 
@@ -726,6 +784,35 @@ mod tests {
             &DefaultsConfig::default(),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn ssrf_guard_rejects_internal_addresses() {
+        use std::net::IpAddr;
+        // Rejected (SSRF targets).
+        for s in [
+            "127.0.0.1",
+            "10.0.0.1",
+            "192.168.1.1",
+            "172.16.0.1",
+            "169.254.169.254", // cloud metadata
+            "0.0.0.0",
+            "::1",
+            "fe80::1",
+            "fc00::1",
+        ] {
+            assert!(
+                !is_public_ip(&s.parse::<IpAddr>().unwrap()),
+                "{s} must be blocked"
+            );
+        }
+        // Allowed (public).
+        for s in ["8.8.8.8", "1.1.1.1", "2606:4700:4700::1111"] {
+            assert!(
+                is_public_ip(&s.parse::<IpAddr>().unwrap()),
+                "{s} must be allowed"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #95

## What
- **Gemini http(s)-URL images** (`providers/gemini.rs`) — Gemini can't fetch an arbitrary URL, so the adapter now downloads http(s) image parts and inlines them as `data:` URLs (which `convert_message` turns into `inline_data`). `data:` images are left untouched; a fetch failure leaves the URL as-is (falls back to the previous behaviour). Runs before request building in both `chat` and `chat_stream`.
- **`tool_result` non-text blocks** (`anthropic_types.rs`) — OpenAI `tool` role messages are **text-only** (an API constraint), so images inside a tool result can't be represented. The text is preserved and non-text blocks now emit a `warn!` instead of being dropped silently.
- **Unknown/`document` blocks** — already warn (from #91).

## Tests (2 new, 247 total)
- `data_url_images_are_not_refetched` — a `data:` image is left untouched (no network).
- `tool_result_non_text_dropped_text_kept` — text preserved, image dropped.

## Note (not a deferral — a genuine format constraint)
OpenAI's internal `tool` message shape is text-only, so `tool_result` images cannot be carried through to any provider via the OpenAI-normalised internal model without a broader message-model change. This PR makes that loss **explicit** (warned + text kept) rather than silent. No follow-up issue filed.

## Security
The remote-image fetch is a client-controlled URL, so it's guarded against **SSRF**: http(s) only, hosts resolving to loopback/private/link-local (incl. cloud-metadata 169.254.169.254)/unspecified addresses are refused, and the download is size-capped (20 MiB). Covered by `ssrf_guard_rejects_internal_addresses`.