### PR TITLE
feat: wire metrics route to respect MetricsConfig (#107)

### DIFF
--- a/docs/user/observability.md
+++ b/docs/user/observability.md
@@ -36,7 +36,20 @@ Every completed request emits a structured log line at `info` level:
 
 ## Prometheus metrics
 
-Metrics are available at `GET /metrics`. All metric names are prefixed `ferrox_`.
+Metrics are available at `GET /metrics` (the default path). All metric names are
+prefixed `ferrox_`. The endpoint is a public, unauthenticated route.
+
+Both the exposure and the path are configurable under `telemetry.metrics`:
+
+```yaml
+telemetry:
+  metrics:
+    enabled: true        # set false to not mount the endpoint at all
+    path: /metrics       # serve at a custom path, e.g. /internal/metrics
+```
+
+When `enabled: false`, the route is not mounted and requests to it return `404`.
+When `path` is set, metrics are served only at that path.
 
 ### Request metrics
 

--- a/ferrox/src/config.rs
+++ b/ferrox/src/config.rs
@@ -587,6 +587,16 @@ pub(crate) fn validate(config: &Config) -> Result<(), anyhow::Error> {
         bail!("rate_limiting.backend is 'redis' but redis_url is not set");
     }
 
+    // Validate the metrics route path: it is mounted verbatim on the router,
+    // and axum panics at startup on a path that doesn't start with '/'. Fail
+    // here with a clear message instead.
+    if config.telemetry.metrics.enabled && !config.telemetry.metrics.path.starts_with('/') {
+        bail!(
+            "telemetry.metrics.path must start with '/', got '{}'",
+            config.telemetry.metrics.path
+        );
+    }
+
     // Validate model routing references
     for m in &config.models {
         if m.routing.targets.is_empty() {
@@ -786,6 +796,22 @@ mod tests {
         config.models[0].routing.targets.clear();
         let err = validate(&config).unwrap_err().to_string();
         assert!(err.contains("at least one target"));
+    }
+
+    #[test]
+    fn validate_rejects_metrics_path_without_leading_slash() {
+        let mut config = minimal_config("openai", "gpt-4");
+        config.telemetry.metrics.path = "metrics".to_string();
+        let err = validate(&config).unwrap_err().to_string();
+        assert!(err.contains("telemetry.metrics.path must start with '/'"));
+    }
+
+    #[test]
+    fn validate_ignores_metrics_path_when_disabled() {
+        let mut config = minimal_config("openai", "gpt-4");
+        config.telemetry.metrics.enabled = false;
+        config.telemetry.metrics.path = "not-a-path".to_string();
+        assert!(validate(&config).is_ok());
     }
 
     #[test]

--- a/ferrox/src/server.rs
+++ b/ferrox/src/server.rs
@@ -43,11 +43,17 @@ pub fn build_router(state: AppState) -> Router {
             auth_middleware,
         ));
 
-    // Public routes (no auth)
-    let public_routes = Router::new()
+    // Public routes (no auth). The metrics endpoint is mounted only when
+    // enabled, at its configured path — honoring `telemetry.metrics`
+    // (`enabled` + `path`), which was previously ignored (the route was
+    // hardcoded at `/metrics` and always mounted).
+    let mut public_routes = Router::new()
         .route("/healthz", get(healthz))
-        .route("/readyz", get(readyz))
-        .route("/metrics", get(metrics_handler));
+        .route("/readyz", get(readyz));
+    let metrics = &state.config.telemetry.metrics;
+    if metrics.enabled {
+        public_routes = public_routes.route(&metrics.path, get(metrics_handler));
+    }
 
     Router::new()
         .merge(v1_routes)
@@ -69,4 +75,91 @@ async fn metrics_handler() -> impl axum::response::IntoResponse {
         )],
         body,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+    use tower::ServiceExt; // for `oneshot`
+
+    /// Build a minimal `AppState` for router tests. All config fields default
+    /// except `providers`/`models` (required by deserialization); the caller
+    /// tweaks `telemetry.metrics` before calling.
+    fn build_state(config: Config) -> AppState {
+        let registry: crate::providers::ProviderRegistry = std::collections::HashMap::new();
+        let router = crate::router::ModelRouter::from_config(&config, &registry).unwrap();
+        let jwks_cache = crate::jwks::JwksCache::new(vec![], 300, reqwest::Client::new());
+        AppState {
+            config: Arc::new(config),
+            providers: Arc::new(registry),
+            router: Arc::new(router),
+            rate_limit_backend: Arc::new(crate::ratelimit::MemoryBackend::new()),
+            metrics: Arc::new(crate::metrics::Metrics::new()),
+            ready: Arc::new(AtomicBool::new(true)),
+            jwks_cache: Arc::new(jwks_cache),
+            usage_writer: crate::usage_writer::noop_writer(),
+            budget_enforcer: Arc::new(crate::budget_enforcer::NoopBudgetEnforcer),
+            event_dispatcher: crate::event_dispatcher::noop_dispatcher(),
+        }
+    }
+
+    fn minimal_config() -> Config {
+        serde_json::from_value(serde_json::json!({"providers": [], "models": []})).unwrap()
+    }
+
+    /// GET `path` against the built router, returning the response status.
+    async fn get_status(config: Config, path: &str) -> StatusCode {
+        let app = build_router(build_state(config));
+        let resp = app
+            .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        resp.status()
+    }
+
+    #[tokio::test]
+    async fn metrics_route_served_at_default_path_when_enabled() {
+        // Default config: enabled = true, path = "/metrics".
+        assert_eq!(
+            get_status(minimal_config(), "/metrics").await,
+            StatusCode::OK
+        );
+    }
+
+    #[tokio::test]
+    async fn metrics_route_absent_when_disabled() {
+        let mut config = minimal_config();
+        config.telemetry.metrics.enabled = false;
+        assert_eq!(
+            get_status(config, "/metrics").await,
+            StatusCode::NOT_FOUND,
+            "metrics route must not be mounted when disabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn metrics_route_served_at_custom_path() {
+        let mut config = minimal_config();
+        config.telemetry.metrics.path = "/internal/metrics".to_string();
+        // Served at the custom path...
+        assert_eq!(
+            get_status(config.clone(), "/internal/metrics").await,
+            StatusCode::OK
+        );
+        // ...and no longer at the hardcoded default.
+        assert_eq!(get_status(config, "/metrics").await, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn health_routes_unaffected_by_metrics_config() {
+        let mut config = minimal_config();
+        config.telemetry.metrics.enabled = false;
+        assert_eq!(get_status(config.clone(), "/healthz").await, StatusCode::OK);
+        assert_eq!(get_status(config, "/readyz").await, StatusCode::OK);
+    }
 }


### PR DESCRIPTION
Closes #107

## What
`telemetry.metrics { enabled, path }` was defined (`ferrox/src/config.rs:80`) but ignored: `build_router` hardcoded `GET /metrics` and mounted it unconditionally (`ferrox/src/server.rs:50`). So `enabled = false` had no effect and a custom `path` did nothing.

## How
In `build_router`, read `state.config.telemetry.metrics` and conditionally mount the metrics route at the configured path:

```rust
let mut public_routes = Router::new()
    .route("/healthz", get(healthz))
    .route("/readyz", get(readyz));
let metrics = &state.config.telemetry.metrics;
if metrics.enabled {
    public_routes = public_routes.route(&metrics.path, get(metrics_handler));
}
```

The endpoint remains public/unauthenticated (unchanged behavior).

## Tests
New `server::tests` (router built via `build_router`, exercised with `tower::oneshot`):
- default config → `GET /metrics` = 200
- `enabled = false` → `GET /metrics` = 404 (route not mounted)
- custom `path` → served at the custom path (200), and 404 at `/metrics`
- `/healthz` + `/readyz` unaffected when metrics disabled

## Docs
`docs/user/observability.md` now documents `telemetry.metrics.{enabled,path}`.

## Notes
Not tied to a formal WHAT/WHY/HOW refinement, but scope is exactly the issue body. Local gates green: `cargo fmt --check`, `cargo clippy -p ferrox --all-targets -- -D warnings`, `cargo test -p ferrox` (4 new tests + existing). `ferrox`-only change; touches the same `build_router` public-routes block as #109 (sequenced before it).