### PR TITLE
feat: expose gateway OpenAPI schema at /api-schema + /openapi.json (#109)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,6 +1441,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "utoipa",
  "uuid",
 ]
 
@@ -2117,6 +2118,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2749,6 +2752,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -3819,6 +3846,16 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
@@ -4347,6 +4384,31 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "uuid"

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -201,6 +201,7 @@ ferrox/src/
   router.rs           ModelRouter: alias -> Arc<RoutePool>
   error.rs            ProxyError enum, OpenAI-format HTTP responses
   types.rs            OpenAI wire types (request, response, chunk)
+  openapi.rs          utoipa ApiDoc: OpenAPI 3.x spec served at /api-schema + /openapi.json
   retry.rs            execute_with_retry, is_retryable, backoff_duration
   metrics.rs          thin shim: initialises telemetry::metrics at startup
 
@@ -234,6 +235,13 @@ ferrox/src/
     health.rs         /healthz, /readyz
     models.rs         /v1/models
 ```
+
+The gateway serves its own OpenAPI 3.x document (built at compile time by
+`utoipa` from `#[utoipa::path]` handler annotations and `ToSchema` types) from a
+cold, unauthenticated `GET /api-schema` (alias `GET /openapi.json`) — the only
+API-discovery surface for gateway-only deployments. The committed
+`ferrox/openapi.json` snapshot is drift-guarded by a test. The control-plane's
+REST API is tracked separately for its own schema.
 
 ---
 

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -316,6 +316,20 @@ No authentication required. See [Observability](observability.md) for the full m
 
 ---
 
+## GET /api-schema · GET /openapi.json
+
+OpenAPI 3.x document describing the gateway's HTTP surface (content type `application/json`). Both paths serve the same document — `/openapi.json` is the convention most SDK generators and API clients auto-detect; `/api-schema` is a friendly alias.
+
+No authentication required. Useful for gateway-only deployments (no control plane) to discover the API, generate typed SDKs, or import into Postman/Insomnia.
+
+The Ferrox-owned shapes (`/v1/models`, `/anthropic/v1/models`, the error envelope) are modeled fully. The `/v1/chat/completions` and `/anthropic/v1/messages` bodies mirror the upstream OpenAI / Anthropic wire formats — only the fields Ferrox owns are modeled, with a reference to the upstream specs for the exhaustive tail.
+
+```bash
+curl http://localhost:8080/openapi.json | jq .
+```
+
+---
+
 ## Using the Anthropic SDK / Claude Code CLI
 
 Point `ANTHROPIC_BASE_URL` at the `/anthropic` prefix. The SDK appends `/v1/messages` automatically.

--- a/ferrox/Cargo.toml
+++ b/ferrox/Cargo.toml
@@ -19,6 +19,9 @@ axum = { version = "0.7", features = ["macros"] }
 tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.5", features = ["trace", "cors", "request-id", "timeout", "compression-gzip"] }
 
+# OpenAPI schema generation (compile-time; served from a cold public route)
+utoipa = { version = "4", features = ["axum_extras"] }
+
 # HTTP client
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 

--- a/ferrox/openapi.json
+++ b/ferrox/openapi.json
@@ -1,0 +1,525 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Ferrox Gateway API",
+    "description": "Stateless, OpenAI-compatible LLM gateway. Exposes OpenAI-format and Anthropic-native inference routes plus operational endpoints. The chat/messages request and response bodies mirror the upstream OpenAI / Anthropic wire formats — only the fields Ferrox owns are modeled here; refer to the upstream specs for the exhaustive schema.",
+    "license": {
+      "name": "MIT"
+    },
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/anthropic/v1/messages": {
+      "post": {
+        "tags": [
+          "Anthropic"
+        ],
+        "operationId": "anthropic_messages",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnthropicMessagesRequestCore"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Message response. JSON body (mirrors the Anthropic Messages response), or an Anthropic SSE event stream when `stream=true`."
+          },
+          "401": {
+            "description": "Missing or invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Model not permitted for this key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown model alias",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limited or budget exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream provider error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key_auth": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/anthropic/v1/models": {
+      "get": {
+        "tags": [
+          "Anthropic"
+        ],
+        "operationId": "list_models_anthropic",
+        "responses": {
+          "200": {
+            "description": "Configured model aliases in Anthropic list format",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnthropicModelsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key_auth": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/healthz": {
+      "get": {
+        "tags": [
+          "Observability"
+        ],
+        "operationId": "healthz",
+        "responses": {
+          "200": {
+            "description": "Process is alive"
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "tags": [
+          "Observability"
+        ],
+        "summary": "Documentation-only stub for the Prometheus metrics endpoint. It has no",
+        "description": "dedicated handler function (it's a closure over `gather()` in `server.rs`),\nso its path item is described here. Public, unauthenticated; present only\nwhen `telemetry.metrics.enabled` (default true), at `telemetry.metrics.path`\n(default `/metrics`).",
+        "operationId": "metrics_doc",
+        "responses": {
+          "200": {
+            "description": "Prometheus/OpenMetrics text exposition"
+          }
+        }
+      }
+    },
+    "/readyz": {
+      "get": {
+        "tags": [
+          "Observability"
+        ],
+        "operationId": "readyz",
+        "responses": {
+          "200": {
+            "description": "Ready to serve traffic"
+          },
+          "503": {
+            "description": "Not ready (still starting or draining)"
+          }
+        }
+      }
+    },
+    "/v1/chat/completions": {
+      "post": {
+        "tags": [
+          "OpenAI"
+        ],
+        "operationId": "chat_completions",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatCompletionRequestCore"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Chat completion. JSON body (mirrors the OpenAI Chat Completions response), or an SSE stream of `chat.completion.chunk` events terminated by `data: [DONE]` when `stream=true`."
+          },
+          "401": {
+            "description": "Missing or invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Model not permitted for this key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown model alias",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limited or budget exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream provider error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/models": {
+      "get": {
+        "tags": [
+          "OpenAI"
+        ],
+        "operationId": "list_models",
+        "responses": {
+          "200": {
+            "description": "Configured model aliases in OpenAI list format",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AnthropicMessagesRequestCore": {
+        "type": "object",
+        "description": "Core of the Anthropic-format messages request. As with the OpenAI path, the\nfull body is forwarded upstream; only owned fields are modeled. See\n<https://docs.anthropic.com/en/api/messages> for the exhaustive schema.\n\nSchema-only (see `ChatCompletionRequestCore`): describes the request body,\nnot read at runtime.",
+        "required": [
+          "model",
+          "max_tokens",
+          "messages"
+        ],
+        "properties": {
+          "max_tokens": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Upper bound on tokens to generate (Anthropic requires this field).",
+            "example": 1024,
+            "minimum": 0
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "Conversation messages in Anthropic format. Modeled here as opaque\nobjects; see the upstream spec for the content-block union."
+          },
+          "model": {
+            "type": "string",
+            "description": "Model alias to route to — one of the aliases from `GET /anthropic/v1/models`.",
+            "example": "claude-sonnet"
+          },
+          "stream": {
+            "type": "boolean",
+            "description": "When `true`, the response is streamed as Anthropic SSE events.",
+            "nullable": true
+          }
+        }
+      },
+      "AnthropicModelObject": {
+        "type": "object",
+        "required": [
+          "type",
+          "id",
+          "display_name",
+          "created_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "RFC 3339 timestamp; the gateway emits an empty string (aliases are not\nversioned)."
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The model alias configured in the gateway.",
+            "example": "claude-sonnet"
+          },
+          "type": {
+            "type": "string",
+            "description": "Always `\"model\"`.",
+            "example": "model"
+          }
+        }
+      },
+      "AnthropicModelsResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AnthropicModelObject"
+            }
+          },
+          "first_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "last_id": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ChatCompletionRequestCore": {
+        "type": "object",
+        "description": "Core of the OpenAI-format chat request. Ferrox forwards the **full** OpenAI\nChat Completions body upstream; only the fields the gateway reads/owns are\nmodeled. See <https://platform.openai.com/docs/api-reference/chat/create>\nfor the exhaustive schema (messages content unions, tools, etc.).\n\nSchema-only: the fields exist to describe the request body, not to be read\nat runtime (the real request type is `crate::types::ChatCompletionRequest`).",
+        "required": [
+          "model",
+          "messages"
+        ],
+        "properties": {
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "Conversation messages in OpenAI format. Modeled here as opaque objects;\nsee the upstream spec for the role/content/tool-call union."
+          },
+          "model": {
+            "type": "string",
+            "description": "Model alias to route to — one of the aliases returned by `GET /v1/models`.",
+            "example": "claude-sonnet"
+          },
+          "stream": {
+            "type": "boolean",
+            "description": "When `true`, the response is streamed as SSE chunks terminated by a\nfinal `data: [DONE]` sentinel.",
+            "nullable": true
+          }
+        }
+      },
+      "ErrorDetail": {
+        "type": "object",
+        "required": [
+          "message",
+          "type",
+          "code"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32",
+            "description": "HTTP status code, duplicated in the body for convenience.",
+            "example": 404,
+            "minimum": 0
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message.",
+            "example": "Model not found: gpt-5"
+          },
+          "type": {
+            "type": "string",
+            "description": "Machine-readable error category (e.g. `unauthorized`, `model_not_found`,\n`rate_limited`, `provider_error`).",
+            "example": "model_not_found"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "description": "The gateway error envelope: every error response is `{\"error\": {...}}`.\nMirrors the shape produced by `crate::error::ProxyError`.",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/ErrorDetail"
+          }
+        }
+      },
+      "ModelObject": {
+        "type": "object",
+        "required": [
+          "id",
+          "object",
+          "created",
+          "owned_by"
+        ],
+        "properties": {
+          "created": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unix timestamp; the gateway emits `0` (aliases are not versioned).",
+            "minimum": 0
+          },
+          "id": {
+            "type": "string",
+            "description": "The model alias configured in the gateway.",
+            "example": "claude-sonnet"
+          },
+          "object": {
+            "type": "string",
+            "description": "Always `\"model\"`.",
+            "example": "model"
+          },
+          "owned_by": {
+            "type": "string",
+            "description": "Always `\"proxy\"`.",
+            "example": "proxy"
+          }
+        }
+      },
+      "ModelsResponse": {
+        "type": "object",
+        "required": [
+          "object",
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModelObject"
+            }
+          },
+          "object": {
+            "type": "string",
+            "description": "Always `\"list\"`.",
+            "example": "list"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "api_key_auth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key"
+      },
+      "bearer_auth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "OpenAI",
+      "description": "OpenAI-compatible inference routes (Authorization: Bearer)"
+    },
+    {
+      "name": "Anthropic",
+      "description": "Anthropic-native inference routes (x-api-key or Bearer)"
+    },
+    {
+      "name": "Observability",
+      "description": "Health and metrics (public, unauthenticated)"
+    }
+  ]
+}

--- a/ferrox/src/anthropic_types.rs
+++ b/ferrox/src/anthropic_types.rs
@@ -163,7 +163,7 @@ pub struct AnthropicUsage {
 
 // ── Models list response ─────────────────────────────────────────────────────
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct AnthropicModelsResponse {
     pub data: Vec<AnthropicModelObject>,
     pub has_more: bool,
@@ -171,12 +171,18 @@ pub struct AnthropicModelsResponse {
     pub last_id: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct AnthropicModelObject {
+    /// Always `"model"`.
     #[serde(rename = "type")]
+    #[schema(rename = "type", example = "model")]
     pub object_type: String,
+    /// The model alias configured in the gateway.
+    #[schema(example = "claude-sonnet")]
     pub id: String,
     pub display_name: String,
+    /// RFC 3339 timestamp; the gateway emits an empty string (aliases are not
+    /// versioned).
     pub created_at: String,
 }
 

--- a/ferrox/src/handlers/anthropic_messages.rs
+++ b/ferrox/src/handlers/anthropic_messages.rs
@@ -83,6 +83,22 @@ fn proxy_error_to_anthropic_response(e: &ProxyError) -> Response {
     (status, Json(body)).into_response()
 }
 
+#[utoipa::path(
+    post,
+    path = "/anthropic/v1/messages",
+    tag = "Anthropic",
+    security(("api_key_auth" = []), ("bearer_auth" = [])),
+    request_body = AnthropicMessagesRequestCore,
+    responses(
+        (status = 200, description = "Message response. JSON body (mirrors the Anthropic \
+            Messages response), or an Anthropic SSE event stream when `stream=true`."),
+        (status = 401, description = "Missing or invalid credentials", body = ErrorResponse),
+        (status = 403, description = "Model not permitted for this key", body = ErrorResponse),
+        (status = 404, description = "Unknown model alias", body = ErrorResponse),
+        (status = 429, description = "Rate limited or budget exceeded", body = ErrorResponse),
+        (status = 502, description = "Upstream provider error", body = ErrorResponse),
+    )
+)]
 pub async fn anthropic_messages(
     State(state): State<AppState>,
     Extension(ctx): Extension<RequestContext>,

--- a/ferrox/src/handlers/anthropic_models.rs
+++ b/ferrox/src/handlers/anthropic_models.rs
@@ -3,6 +3,16 @@ use axum::{extract::State, Json};
 use crate::anthropic_types::{AnthropicModelObject, AnthropicModelsResponse};
 use crate::state::AppState;
 
+#[utoipa::path(
+    get,
+    path = "/anthropic/v1/models",
+    tag = "Anthropic",
+    security(("api_key_auth" = []), ("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Configured model aliases in Anthropic list format", body = AnthropicModelsResponse),
+        (status = 401, description = "Missing or invalid credentials", body = ErrorResponse),
+    )
+)]
 pub async fn list_models_anthropic(State(state): State<AppState>) -> Json<AnthropicModelsResponse> {
     let data: Vec<AnthropicModelObject> = state
         .config

--- a/ferrox/src/handlers/chat.rs
+++ b/ferrox/src/handlers/chat.rs
@@ -22,6 +22,23 @@ use crate::telemetry::metrics::{
 use crate::types::{ChatCompletionRequest, ChatCompletionResponse, RequestContext};
 use crate::usage_writer::UsageEvent;
 
+#[utoipa::path(
+    post,
+    path = "/v1/chat/completions",
+    tag = "OpenAI",
+    security(("bearer_auth" = [])),
+    request_body = ChatCompletionRequestCore,
+    responses(
+        (status = 200, description = "Chat completion. JSON body (mirrors the OpenAI Chat \
+            Completions response), or an SSE stream of `chat.completion.chunk` events \
+            terminated by `data: [DONE]` when `stream=true`."),
+        (status = 401, description = "Missing or invalid credentials", body = ErrorResponse),
+        (status = 403, description = "Model not permitted for this key", body = ErrorResponse),
+        (status = 404, description = "Unknown model alias", body = ErrorResponse),
+        (status = 429, description = "Rate limited or budget exceeded", body = ErrorResponse),
+        (status = 502, description = "Upstream provider error", body = ErrorResponse),
+    )
+)]
 pub async fn chat_completions(
     State(state): State<AppState>,
     Extension(ctx): Extension<RequestContext>,

--- a/ferrox/src/handlers/health.rs
+++ b/ferrox/src/handlers/health.rs
@@ -3,10 +3,25 @@ use std::sync::atomic::Ordering;
 
 use crate::state::AppState;
 
+#[utoipa::path(
+    get,
+    path = "/healthz",
+    tag = "Observability",
+    responses((status = 200, description = "Process is alive"))
+)]
 pub async fn healthz() -> impl IntoResponse {
     (StatusCode::OK, Json(serde_json::json!({ "status": "ok" })))
 }
 
+#[utoipa::path(
+    get,
+    path = "/readyz",
+    tag = "Observability",
+    responses(
+        (status = 200, description = "Ready to serve traffic"),
+        (status = 503, description = "Not ready (still starting or draining)")
+    )
+)]
 pub async fn readyz(State(state): State<AppState>) -> impl IntoResponse {
     if state.ready.load(Ordering::Acquire) {
         (

--- a/ferrox/src/handlers/models.rs
+++ b/ferrox/src/handlers/models.rs
@@ -3,6 +3,16 @@ use axum::{extract::State, Json};
 use crate::state::AppState;
 use crate::types::{ModelObject, ModelsResponse};
 
+#[utoipa::path(
+    get,
+    path = "/v1/models",
+    tag = "OpenAI",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Configured model aliases in OpenAI list format", body = ModelsResponse),
+        (status = 401, description = "Missing or invalid credentials", body = ErrorResponse),
+    )
+)]
 pub async fn list_models(State(state): State<AppState>) -> Json<ModelsResponse> {
     let data = state
         .config

--- a/ferrox/src/main.rs
+++ b/ferrox/src/main.rs
@@ -8,6 +8,7 @@ mod handlers;
 mod jwks;
 mod lb;
 mod metrics;
+mod openapi;
 mod providers;
 mod ratelimit;
 mod retry;

--- a/ferrox/src/openapi.rs
+++ b/ferrox/src/openapi.rs
@@ -1,0 +1,266 @@
+//! OpenAPI 3.1 schema for the gateway's HTTP surface.
+//!
+//! The document is built at compile time by `utoipa` from the `#[utoipa::path]`
+//! annotations on the handlers plus the `ToSchema`-deriving types, and served
+//! from a cold, unauthenticated `/schema` (alias `/openapi.json`) route — no
+//! hot-path impact.
+//!
+//! Scope guardrail: the `/v1/chat/completions` and `/anthropic/v1/messages`
+//! bodies mirror the upstream OpenAI / Anthropic wire formats (streaming deltas,
+//! tool-call unions, multimodal content blocks). Reproducing those in full would
+//! be huge and would drift, so only the fields Ferrox itself owns/reads are
+//! modeled here, with a pointer to the upstream spec for the exhaustive tail.
+//! The shapes Ferrox fully owns (`/v1/models`, `/anthropic/v1/models`, the error
+//! envelope) are modeled completely.
+
+use once_cell::sync::Lazy;
+use serde::Serialize;
+use utoipa::openapi::security::{ApiKey, ApiKeyValue, Http, HttpAuthScheme, SecurityScheme};
+use utoipa::{Modify, OpenApi, ToSchema};
+
+/// The gateway error envelope: every error response is `{"error": {...}}`.
+/// Mirrors the shape produced by `crate::error::ProxyError`.
+#[derive(Serialize, ToSchema)]
+pub struct ErrorResponse {
+    pub error: ErrorDetail,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct ErrorDetail {
+    /// Human-readable error message.
+    #[schema(example = "Model not found: gpt-5")]
+    pub message: String,
+    /// Machine-readable error category (e.g. `unauthorized`, `model_not_found`,
+    /// `rate_limited`, `provider_error`).
+    #[schema(rename = "type", example = "model_not_found")]
+    pub error_type: String,
+    /// HTTP status code, duplicated in the body for convenience.
+    #[schema(example = 404)]
+    pub code: u16,
+}
+
+/// Core of the OpenAI-format chat request. Ferrox forwards the **full** OpenAI
+/// Chat Completions body upstream; only the fields the gateway reads/owns are
+/// modeled. See <https://platform.openai.com/docs/api-reference/chat/create>
+/// for the exhaustive schema (messages content unions, tools, etc.).
+///
+/// Schema-only: the fields exist to describe the request body, not to be read
+/// at runtime (the real request type is `crate::types::ChatCompletionRequest`).
+#[derive(ToSchema)]
+#[allow(dead_code)]
+pub struct ChatCompletionRequestCore {
+    /// Model alias to route to — one of the aliases returned by `GET /v1/models`.
+    #[schema(example = "claude-sonnet")]
+    pub model: String,
+    /// Conversation messages in OpenAI format. Modeled here as opaque objects;
+    /// see the upstream spec for the role/content/tool-call union.
+    #[schema(value_type = Vec<Object>)]
+    pub messages: Vec<serde_json::Value>,
+    /// When `true`, the response is streamed as SSE chunks terminated by a
+    /// final `data: [DONE]` sentinel.
+    pub stream: Option<bool>,
+}
+
+/// Core of the Anthropic-format messages request. As with the OpenAI path, the
+/// full body is forwarded upstream; only owned fields are modeled. See
+/// <https://docs.anthropic.com/en/api/messages> for the exhaustive schema.
+///
+/// Schema-only (see `ChatCompletionRequestCore`): describes the request body,
+/// not read at runtime.
+#[derive(ToSchema)]
+#[allow(dead_code)]
+pub struct AnthropicMessagesRequestCore {
+    /// Model alias to route to — one of the aliases from `GET /anthropic/v1/models`.
+    #[schema(example = "claude-sonnet")]
+    pub model: String,
+    /// Upper bound on tokens to generate (Anthropic requires this field).
+    #[schema(example = 1024)]
+    pub max_tokens: u32,
+    /// Conversation messages in Anthropic format. Modeled here as opaque
+    /// objects; see the upstream spec for the content-block union.
+    #[schema(value_type = Vec<Object>)]
+    pub messages: Vec<serde_json::Value>,
+    /// When `true`, the response is streamed as Anthropic SSE events.
+    pub stream: Option<bool>,
+}
+
+/// Adds the two authentication schemes the gateway accepts to the spec's
+/// components so annotated routes can reference them.
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi
+            .components
+            .as_mut()
+            .expect("components exist once schemas are registered");
+        // OpenAI-format routes: `Authorization: Bearer <virtual key | JWT>`.
+        components.add_security_scheme(
+            "bearer_auth",
+            SecurityScheme::Http(Http::new(HttpAuthScheme::Bearer)),
+        );
+        // Anthropic-native routes also accept `x-api-key: <virtual key>`.
+        components.add_security_scheme(
+            "api_key_auth",
+            SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("x-api-key"))),
+        );
+    }
+}
+
+/// Documentation-only stub for the Prometheus metrics endpoint. It has no
+/// dedicated handler function (it's a closure over `gather()` in `server.rs`),
+/// so its path item is described here. Public, unauthenticated; present only
+/// when `telemetry.metrics.enabled` (default true), at `telemetry.metrics.path`
+/// (default `/metrics`).
+#[utoipa::path(
+    get,
+    path = "/metrics",
+    tag = "Observability",
+    responses(
+        (status = 200, description = "Prometheus/OpenMetrics text exposition", content_type = "text/plain")
+    )
+)]
+#[allow(dead_code)]
+fn metrics_doc() {}
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Ferrox Gateway API",
+        description = "Stateless, OpenAI-compatible LLM gateway. Exposes OpenAI-format and \
+                       Anthropic-native inference routes plus operational endpoints. The \
+                       chat/messages request and response bodies mirror the upstream OpenAI / \
+                       Anthropic wire formats — only the fields Ferrox owns are modeled here; \
+                       refer to the upstream specs for the exhaustive schema.",
+    ),
+    paths(
+        crate::handlers::chat::chat_completions,
+        crate::handlers::models::list_models,
+        crate::handlers::anthropic_messages::anthropic_messages,
+        crate::handlers::anthropic_models::list_models_anthropic,
+        crate::handlers::health::healthz,
+        crate::handlers::health::readyz,
+        metrics_doc,
+    ),
+    components(schemas(
+        ErrorResponse,
+        ErrorDetail,
+        ChatCompletionRequestCore,
+        AnthropicMessagesRequestCore,
+        crate::types::ModelsResponse,
+        crate::types::ModelObject,
+        crate::anthropic_types::AnthropicModelsResponse,
+        crate::anthropic_types::AnthropicModelObject,
+    )),
+    modifiers(&SecurityAddon),
+    tags(
+        (name = "OpenAI", description = "OpenAI-compatible inference routes (Authorization: Bearer)"),
+        (name = "Anthropic", description = "Anthropic-native inference routes (x-api-key or Bearer)"),
+        (name = "Observability", description = "Health and metrics (public, unauthenticated)"),
+    )
+)]
+pub struct ApiDoc;
+
+/// The generated OpenAPI document as a pretty-printed JSON string, built once.
+/// The `info.version` is stamped from the crate version at build time (utoipa's
+/// `info(version=...)` attribute only accepts a string literal, so it's set
+/// here instead).
+static OPENAPI_JSON: Lazy<String> = Lazy::new(|| {
+    let mut doc = ApiDoc::openapi();
+    doc.info.version = env!("CARGO_PKG_VERSION").to_string();
+    doc.to_pretty_json()
+        .expect("OpenAPI document serializes to JSON")
+});
+
+/// Cached OpenAPI JSON served by the `/api-schema` and `/openapi.json` routes.
+pub fn openapi_json() -> &'static str {
+    OPENAPI_JSON.as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Absolute path to the committed snapshot, read at runtime (not via
+    /// `include_str!`) so the crate still compiles before the file is first
+    /// generated by `regenerate_committed_snapshot`.
+    const SNAPSHOT_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/openapi.json");
+
+    #[test]
+    fn document_is_valid_openapi_3x() {
+        let v: serde_json::Value = serde_json::from_str(openapi_json()).unwrap();
+        assert!(
+            v["openapi"].as_str().unwrap_or_default().starts_with("3."),
+            "openapi version must be 3.x, got {:?}",
+            v["openapi"]
+        );
+        assert!(v["info"]["title"].is_string());
+        assert!(v["paths"].is_object());
+    }
+
+    #[test]
+    fn all_gateway_routes_are_enumerated() {
+        let v: serde_json::Value = serde_json::from_str(openapi_json()).unwrap();
+        let paths = &v["paths"];
+        for p in [
+            "/v1/chat/completions",
+            "/v1/models",
+            "/anthropic/v1/messages",
+            "/anthropic/v1/models",
+            "/healthz",
+            "/readyz",
+            "/metrics",
+        ] {
+            assert!(paths.get(p).is_some(), "route {p} missing from schema");
+        }
+    }
+
+    #[test]
+    fn owned_shapes_and_security_are_modeled() {
+        let v: serde_json::Value = serde_json::from_str(openapi_json()).unwrap();
+        let schemas = &v["components"]["schemas"];
+        for s in [
+            "ErrorResponse",
+            "ErrorDetail",
+            "ModelsResponse",
+            "ModelObject",
+            "AnthropicModelsResponse",
+            "AnthropicModelObject",
+        ] {
+            assert!(schemas.get(s).is_some(), "schema {s} missing");
+        }
+        // Error envelope shape: { error: { message, type, code } }.
+        let props = &schemas["ErrorDetail"]["properties"];
+        assert!(props.get("message").is_some());
+        assert!(props.get("type").is_some(), "error `type` field missing");
+        assert!(props.get("code").is_some());
+        // Both auth schemes present.
+        let sec = &v["components"]["securitySchemes"];
+        assert!(sec["bearer_auth"].is_object());
+        assert!(sec["api_key_auth"].is_object());
+    }
+
+    /// Drift guard: the committed `ferrox/openapi.json` must match the spec
+    /// generated from the code. Regenerate with:
+    /// `cargo test -p ferrox openapi::tests::regenerate_committed_snapshot -- --ignored`
+    #[test]
+    fn committed_snapshot_matches_generated() {
+        let committed = std::fs::read_to_string(SNAPSHOT_PATH).unwrap_or_else(|e| {
+            panic!("committed snapshot {SNAPSHOT_PATH} unreadable ({e}); generate it with the ignored `regenerate_committed_snapshot` test")
+        });
+        assert_eq!(
+            openapi_json().trim(),
+            committed.trim(),
+            "ferrox/openapi.json is out of date — regenerate with the ignored \
+             `regenerate_committed_snapshot` test and commit it"
+        );
+    }
+
+    /// Writes the current spec to the committed snapshot. Ignored by default so
+    /// it never runs in CI; invoke explicitly to (re)generate the file.
+    #[test]
+    #[ignore = "regeneration utility, run explicitly"]
+    fn regenerate_committed_snapshot() {
+        std::fs::write(SNAPSHOT_PATH, format!("{}\n", openapi_json())).unwrap();
+    }
+}

--- a/ferrox/src/openapi.rs
+++ b/ferrox/src/openapi.rs
@@ -2,7 +2,7 @@
 //!
 //! The document is built at compile time by `utoipa` from the `#[utoipa::path]`
 //! annotations on the handlers plus the `ToSchema`-deriving types, and served
-//! from a cold, unauthenticated `/schema` (alias `/openapi.json`) route — no
+//! from a cold, unauthenticated `/api-schema` (alias `/openapi.json`) route — no
 //! hot-path impact.
 //!
 //! Scope guardrail: the `/v1/chat/completions` and `/anthropic/v1/messages`
@@ -238,6 +238,50 @@ mod tests {
         let sec = &v["components"]["securitySchemes"];
         assert!(sec["bearer_auth"].is_object());
         assert!(sec["api_key_auth"].is_object());
+    }
+
+    #[test]
+    fn every_ref_resolves_to_a_registered_schema() {
+        // The core job of an OpenAPI validator: no dangling `$ref`. Referencing
+        // a schema by full path (e.g. `crate::openapi::ErrorResponse`) instead
+        // of its registered component name silently produces an unresolvable
+        // ref, so guard against it here.
+        let v: serde_json::Value = serde_json::from_str(openapi_json()).unwrap();
+        let schemas = &v["components"]["schemas"];
+
+        fn collect_refs<'a>(node: &'a serde_json::Value, out: &mut Vec<&'a str>) {
+            match node {
+                serde_json::Value::Object(map) => {
+                    for (k, val) in map {
+                        if k == "$ref" {
+                            if let Some(s) = val.as_str() {
+                                out.push(s);
+                            }
+                        } else {
+                            collect_refs(val, out);
+                        }
+                    }
+                }
+                serde_json::Value::Array(arr) => arr.iter().for_each(|x| collect_refs(x, out)),
+                _ => {}
+            }
+        }
+
+        let mut refs = Vec::new();
+        collect_refs(&v, &mut refs);
+        assert!(
+            !refs.is_empty(),
+            "expected at least one $ref in the document"
+        );
+        for r in refs {
+            let name = r
+                .strip_prefix("#/components/schemas/")
+                .unwrap_or_else(|| panic!("unexpected $ref form: {r}"));
+            assert!(
+                schemas.get(name).is_some(),
+                "dangling $ref {r}: no component schema named {name:?}"
+            );
+        }
     }
 
     /// Drift guard: the committed `ferrox/openapi.json` must match the spec

--- a/ferrox/src/server.rs
+++ b/ferrox/src/server.rs
@@ -49,7 +49,12 @@ pub fn build_router(state: AppState) -> Router {
     // hardcoded at `/metrics` and always mounted).
     let mut public_routes = Router::new()
         .route("/healthz", get(healthz))
-        .route("/readyz", get(readyz));
+        .route("/readyz", get(readyz))
+        // OpenAPI schema for the gateway surface — discovery/SDK-generation for
+        // gateway-only deployments. Cold, unauthenticated; `/openapi.json` is
+        // the auto-detected convention, `/api-schema` a friendly alias.
+        .route("/api-schema", get(schema_handler))
+        .route("/openapi.json", get(schema_handler));
     let metrics = &state.config.telemetry.metrics;
     if metrics.enabled {
         public_routes = public_routes.route(&metrics.path, get(metrics_handler));
@@ -74,6 +79,15 @@ async fn metrics_handler() -> impl axum::response::IntoResponse {
             "text/plain; version=0.0.4; charset=utf-8",
         )],
         body,
+    )
+}
+
+/// Serve the pre-built OpenAPI document as `application/json`. The body is
+/// cached (built once), so this route allocates nothing per request.
+async fn schema_handler() -> impl axum::response::IntoResponse {
+    (
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        crate::openapi::openapi_json(),
     )
 }
 
@@ -161,5 +175,48 @@ mod tests {
         config.telemetry.metrics.enabled = false;
         assert_eq!(get_status(config.clone(), "/healthz").await, StatusCode::OK);
         assert_eq!(get_status(config, "/readyz").await, StatusCode::OK);
+    }
+
+    /// GET `path`, returning (status, content-type, body bytes).
+    async fn get_full(config: Config, path: &str) -> (StatusCode, String, Vec<u8>) {
+        let app = build_router(build_state(config));
+        let resp = app
+            .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = resp.status();
+        let content_type = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec();
+        (status, content_type, bytes)
+    }
+
+    #[tokio::test]
+    async fn schema_routes_serve_openapi_json_without_auth() {
+        for path in ["/api-schema", "/openapi.json"] {
+            let (status, content_type, body) = get_full(minimal_config(), path).await;
+            assert_eq!(status, StatusCode::OK, "{path} should be public + 200");
+            assert!(
+                content_type.starts_with("application/json"),
+                "{path} content-type was {content_type}"
+            );
+            let doc: serde_json::Value = serde_json::from_slice(&body)
+                .unwrap_or_else(|e| panic!("{path} body must be JSON: {e}"));
+            assert!(
+                doc["openapi"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .starts_with("3."),
+                "{path} must be an OpenAPI 3.x document"
+            );
+            assert!(doc["paths"]["/v1/chat/completions"].is_object());
+        }
     }
 }

--- a/ferrox/src/types.rs
+++ b/ferrox/src/types.rs
@@ -259,17 +259,26 @@ pub struct ChunkDelta {
 
 // ── Models list response ─────────────────────────────────────────────────────
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct ModelsResponse {
+    /// Always `"list"`.
+    #[schema(example = "list")]
     pub object: String,
     pub data: Vec<ModelObject>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct ModelObject {
+    /// The model alias configured in the gateway.
+    #[schema(example = "claude-sonnet")]
     pub id: String,
+    /// Always `"model"`.
+    #[schema(example = "model")]
     pub object: String,
+    /// Unix timestamp; the gateway emits `0` (aliases are not versioned).
     pub created: u64,
+    /// Always `"proxy"`.
+    #[schema(example = "proxy")]
     pub owned_by: String,
 }
 


### PR DESCRIPTION
Closes #109

## What
Generate an OpenAPI 3.x document for the **gateway** HTTP surface and serve it from a cold, unauthenticated route, so gateway-only deployments (no control plane) have a machine-readable discovery surface for SDK generation, client import, and validation.

Served at **`GET /api-schema`** and **`GET /openapi.json`** (same document; `/openapi.json` is the auto-detected convention, `/api-schema` a friendly alias).

> Note: the issue suggested `/schema`; changed to `/api-schema` per maintainer request during implementation.

## Scope decision — gateway now, control-plane split to #112
The issue covered **both** the gateway and the control-plane schemas, and explicitly raised *"one combined issue vs splitting gateway and CP into separate tracked issues"* as an open question, with the gateway as the stated priority (ships independently). To keep this PR focused and reviewable, the **control-plane (`ferrox-cp`) schema is split into #112**, cross-linked. This PR delivers the gateway half fully.

## How
- **`ferrox/src/openapi.rs`** (new): `#[derive(OpenApi)] ApiDoc` aggregating the annotated paths + component schemas; the error envelope (`{"error":{message,type,code}}`) and provider-body **core** schemas; `bearer_auth` (HTTP Bearer) + `api_key_auth` (`x-api-key`) security schemes via a `Modify`; cached pretty-printed JSON (built once — no per-request allocation).
- **Handlers**: `#[utoipa::path]` on `chat_completions`, `list_models`, `anthropic_messages`, `list_models_anthropic`, `healthz`, `readyz`, plus a doc stub for `/metrics`. Each declares method, path, per-route auth, and response refs.
- **`ToSchema`** on the Ferrox-owned types: `ModelsResponse`/`ModelObject`, `AnthropicModelsResponse`/`AnthropicModelObject`.
- **Provider-mirrored bodies** (`/v1/chat/completions`, `/anthropic/v1/messages`): only the fields Ferrox owns are modeled, with the description pointing to the upstream OpenAI/Anthropic specs for the exhaustive tail — per the issue's explicit guardrail (no over-claiming).
- **`server.rs`**: mount `/api-schema` + `/openapi.json` on the public (no-auth) router.
- **Committed `ferrox/openapi.json`** snapshot + **drift-guard test** (regenerate with the ignored `openapi::tests::regenerate_committed_snapshot`).
- **Docs**: `docs/user/api-reference.md` + `docs/developer/architecture.md`.

## Acceptance (this PR)
- [x] `GET /api-schema` and `GET /openapi.json` → valid OpenAPI 3.x, `200`, `application/json`, no auth.
- [x] All gateway routes enumerated with methods + per-route auth.
- [x] Ferrox-owned shapes fully modeled (model lists + error envelope).
- [x] Provider bodies document core fields + reference upstream (no full reproduction).
- [x] Generated doc validated in CI (parse + structural assertions in `openapi::tests`).
- [x] Drift-guard test fails when `ferrox/openapi.json` is stale.
- [ ] Control-plane `/api-schema` → **deferred to #112** (scope split).

## Performance
No hot-path impact: the spec is built at compile time and served from a cold, unauthenticated route serving a cached static string (no locks, no per-request allocation) — consistent with the project's performance goal.

## Testing
`cargo fmt --check`, `cargo clippy -p ferrox --all-targets -- -D warnings`, `cargo test -p ferrox` (265 tests, incl. drift-guard + route serving). `ferrox`-only; `utoipa 4.2` added.