### PR TITLE
fix(lb): fail over to fallback provider on upstream 403 (plan/quota exhaustion)

### DIFF
--- a/ferrox/src/handlers/chat.rs
+++ b/ferrox/src/handlers/chat.rs
@@ -14,7 +14,7 @@ use crate::error::ProxyError;
 use crate::event_dispatcher::TokenUsageEvent;
 use crate::lb::{RoutePool, RouteTarget};
 use crate::providers::ProviderStream;
-use crate::retry::{execute_with_retry, is_retryable};
+use crate::retry::{execute_with_retry, should_failover};
 use crate::state::AppState;
 use crate::telemetry::metrics::{
     self, ACTIVE_STREAMS, ERRORS_TOTAL, FALLBACK_TOTAL, REQUESTS_TOTAL, REQUEST_DURATION_SECONDS,
@@ -366,7 +366,7 @@ pub(crate) async fn dispatch_non_stream(
                 target.circuit_breaker.record_success();
                 return Ok((resp, provider_name, model_id));
             }
-            Err(e) if is_retryable(&e) => {
+            Err(e) if should_failover(&e) => {
                 target.circuit_breaker.record_failure();
                 tracing::warn!(
                     provider = %provider_name,
@@ -447,7 +447,7 @@ pub(crate) async fn dispatch_stream(
                 target.circuit_breaker.record_success();
                 return Ok((stream, provider_name, model_id));
             }
-            Err(e) if is_retryable(&e) => {
+            Err(e) if should_failover(&e) => {
                 target.circuit_breaker.record_failure();
                 tracing::warn!(
                     provider = %provider_name,

--- a/ferrox/src/retry.rs
+++ b/ferrox/src/retry.rs
@@ -29,6 +29,31 @@ pub fn is_retryable(e: &ProxyError) -> bool {
     }
 }
 
+/// Determines whether a primary-target failure should degrade to the fallback
+/// chain (and count as a circuit-breaker failure).
+///
+/// This is deliberately broader than [`is_retryable`]: every transient error
+/// that is worth retrying on the *same* target is also worth failing over, but
+/// in addition an upstream **403** triggers failover here while staying
+/// non-retryable above.
+///
+/// Why 403: some providers report plan/quota exhaustion with 403 rather than
+/// 429 (e.g. Moonshot Kimi's `access_terminated_error` when a coding-plan
+/// billing cycle is used up). Retrying the *same* provider is pointless — it
+/// will keep returning 403 — so [`is_retryable`] leaves it alone and we avoid
+/// wasting backoff sleeps on a provider we know is exhausted. But we DO want to
+/// serve the request from the other provider, and we want the repeated 403s to
+/// trip the circuit breaker so subsequent requests skip the dead provider
+/// entirely until it recovers.
+///
+/// This matches on the UPSTREAM provider's status (`ProviderError`). The
+/// gateway's own auth rejection is `ProxyError::Forbidden`, which must NOT
+/// trigger failover — a client's bad virtual key should fail closed, not burn
+/// the fallback provider's quota.
+pub fn should_failover(e: &ProxyError) -> bool {
+    is_retryable(e) || matches!(e, ProxyError::ProviderError { status: 403, .. })
+}
+
 /// Execute an async operation with retries on the **same target**.
 ///
 /// `provider` and `model_alias` are used for the `ferrox_retries_total` metric.
@@ -203,12 +228,71 @@ mod tests {
     }
 
     #[test]
-    fn provider_4xx_non_429_is_not_retryable() {
+    fn provider_403_is_not_retryable_on_same_target() {
+        // Retrying an exhausted provider is pointless — it keeps returning 403.
         assert!(!is_retryable(&ProxyError::ProviderError {
             provider: "p".into(),
-            status: 400,
-            message: "bad req".into(),
+            status: 403,
+            message: "access_terminated_error".into(),
         }));
+    }
+
+    #[test]
+    fn provider_4xx_non_retryable_status_is_not_retryable() {
+        for status in [400, 404, 422] {
+            assert!(!is_retryable(&ProxyError::ProviderError {
+                provider: "p".into(),
+                status,
+                message: "client error".into(),
+            }));
+        }
+    }
+
+    // ── should_failover ────────────────────────────────────────────────────────
+
+    #[test]
+    fn provider_403_triggers_failover() {
+        // Plan/quota exhaustion reported as 403 (e.g. Kimi's
+        // access_terminated_error) must degrade to the fallback provider and
+        // count toward the circuit breaker.
+        assert!(should_failover(&ProxyError::ProviderError {
+            provider: "p".into(),
+            status: 403,
+            message: "access_terminated_error".into(),
+        }));
+    }
+
+    #[test]
+    fn gateway_forbidden_does_not_trigger_failover() {
+        // The gateway's own auth rejection (bad virtual key) must fail closed,
+        // never burn the fallback provider's quota.
+        assert!(!should_failover(&ProxyError::Forbidden("bad key".into())));
+    }
+
+    #[test]
+    fn retryable_errors_also_trigger_failover() {
+        assert!(should_failover(&ProxyError::UpstreamTimeout("t".into())));
+        assert!(should_failover(&ProxyError::ProviderError {
+            provider: "p".into(),
+            status: 503,
+            message: "down".into(),
+        }));
+        assert!(should_failover(&ProxyError::ProviderError {
+            provider: "p".into(),
+            status: 429,
+            message: "rate".into(),
+        }));
+    }
+
+    #[test]
+    fn provider_4xx_non_403_does_not_trigger_failover() {
+        for status in [400, 401, 404, 422] {
+            assert!(!should_failover(&ProxyError::ProviderError {
+                provider: "p".into(),
+                status,
+                message: "client error".into(),
+            }));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Production `ferrox.shaharialab.com` was serving `k3` (Moonshot/Kimi). When the Kimi coding-plan quota was exhausted, requests started failing with:

```
API Error: 403 {"error":{"message":"You've reached your usage limit for this billing cycle...","type":"access_terminated_error"}}
```

…and the gateway **did not fall over to the configured `glm-5.2` fallback**, even though `k3` is a failover pool with `zai/glm-5.2` as fallback.

### Root cause

Kimi reports plan/quota exhaustion as **HTTP 403 `access_terminated_error`**, not `429`. The failover decision in `dispatch_stream` / `dispatch_non_stream` was gated on `is_retryable()`, which only covers `>= 500`, `429`, timeouts, circuit-open and stream errors. A non-retryable primary error hits `Err(e) => return Err(e)` **before** the fallback loop, so the 403 was passed straight back to the client and the fallback chain was never entered. (The circuit breaker also never tripped, because `record_failure()` only runs on the failover path — so *every* request kept hitting the dead provider.)

## Fix

Separate two concerns that were conflated under `is_retryable`:

- **`is_retryable`** — retry the *same* target with backoff. 403 stays **false** (retrying an exhausted provider is pointless and only wastes backoff sleeps).
- **`should_failover`** (new) — degrade to the fallback chain *and* count as a circuit-breaker failure. Broader than `is_retryable`: additionally treats an upstream **403** as failover-worthy.

The two dispatch guards now use `should_failover`. Net behaviour for a 403:

1. **Immediate** failover to the fallback provider — no wasted same-target retries/backoff.
2. Each 403 records a circuit-breaker failure. After `failure_threshold` (default 5) consecutive failures the breaker **opens**, so subsequent requests skip the dead provider entirely and go straight to the fallback — no repeated calls to Kimi.
3. After `recovery_timeout_secs` (default 30s) the breaker half-opens and sends a single probe; if the provider recovered (new billing cycle) it closes again. This is the "remember it, cool down, periodically re-probe" behaviour, all lock-free on the hot path.

### Not affected

The gateway's own auth rejection (bad virtual key) is `ProxyError::Forbidden`, which is **not** matched by `should_failover` — a client's bad key still fails closed instead of burning the fallback provider's quota.

## Tests

- `provider_403_is_not_retryable_on_same_target`
- `provider_403_triggers_failover`
- `gateway_forbidden_does_not_trigger_failover`
- `retryable_errors_also_trigger_failover`
- `provider_4xx_non_403_does_not_trigger_failover`

Full suite: `283 passed`, clippy clean.