### PR TITLE
fix(anthropic-stream): read input_tokens from message_delta (GLM/Z.AI prompt_tokens=0)

### DIFF
--- a/ferrox/src/providers/anthropic_events.rs
+++ b/ferrox/src/providers/anthropic_events.rs
@@ -19,9 +19,11 @@ pub struct AnthropicEventProcessor {
     pending_tool_index: u32,
     pub stop_reason: Option<String>,
     pub usage: Option<Usage>,
-    /// Prompt tokens from the `message_start` event. Anthropic reports
-    /// `input_tokens` there, not in `message_delta`, so we capture it up front
-    /// and fold it into the final usage.
+    /// Prompt tokens from the `message_start` event. api.anthropic.com reports
+    /// `input_tokens` there, so we capture it up front and fold it into the
+    /// final usage. Anthropic-protocol upstreams differ: Z.AI/GLM send
+    /// `input_tokens: 0` in `message_start` and the real count in the trailing
+    /// `message_delta`, which takes precedence when non-zero.
     input_tokens: u32,
 }
 
@@ -199,12 +201,24 @@ pub fn map_stop_reason(r: &str) -> String {
     }
 }
 
+/// Build the final usage from the trailing `message_delta`.
+///
+/// `input_tokens` is the value captured at `message_start`. A non-zero
+/// `usage.input_tokens` on the delta itself wins — some Anthropic-protocol
+/// upstreams (Z.AI/GLM) only report prompt tokens there. The two values are
+/// never summed: whichever is authoritative is used whole.
 fn parse_usage_from_message_delta(v: &Value, input_tokens: u32) -> Option<Usage> {
     let output = v.pointer("/usage/output_tokens").and_then(|t| t.as_u64())? as u32;
+    let input = v
+        .pointer("/usage/input_tokens")
+        .and_then(|t| t.as_u64())
+        .map(|t| t as u32)
+        .filter(|&t| t > 0)
+        .unwrap_or(input_tokens);
     Some(Usage {
-        prompt_tokens: input_tokens,
+        prompt_tokens: input,
         completion_tokens: output,
-        total_tokens: input_tokens + output,
+        total_tokens: input + output,
         extra: Default::default(),
     })
 }
@@ -471,6 +485,41 @@ mod tests {
         assert_eq!(
             usage.prompt_tokens, 123,
             "prompt tokens must come from message_start"
+        );
+        assert_eq!(usage.completion_tokens, 7);
+        assert_eq!(usage.total_tokens, 130);
+    }
+
+    #[test]
+    fn message_delta_input_tokens_override_zero_start() {
+        let mut p = make_processor();
+        // Z.AI/GLM shape: message_start reports 0, the real count lands on the delta.
+        let start =
+            r#"{"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":0}}}"#;
+        p.process("message_start", start, "glm-4.5-air", "zai");
+        let delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":47,"output_tokens":2}}"#;
+        p.process("message_delta", delta, "glm-4.5-air", "zai");
+        let usage = p.usage.as_ref().unwrap();
+        assert_eq!(
+            usage.prompt_tokens, 47,
+            "a non-zero message_delta input_tokens must win over message_start"
+        );
+        assert_eq!(usage.completion_tokens, 2);
+        assert_eq!(usage.total_tokens, 49);
+    }
+
+    #[test]
+    fn message_delta_zero_input_keeps_message_start() {
+        let mut p = make_processor();
+        let start =
+            r#"{"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":123}}}"#;
+        p.process("message_start", start, "claude-3", "anthropic");
+        let delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":0,"output_tokens":7}}"#;
+        p.process("message_delta", delta, "claude-3", "anthropic");
+        let usage = p.usage.as_ref().unwrap();
+        assert_eq!(
+            usage.prompt_tokens, 123,
+            "a zero message_delta input_tokens must not clobber message_start"
         );
         assert_eq!(usage.completion_tokens, 7);
         assert_eq!(usage.total_tokens, 130);


### PR DESCRIPTION
Closes #124

## What

Read `input_tokens` from the streaming `message_delta` event, not only from `message_start`, so Anthropic-protocol upstreams that report input tokens late (GLM / Z.AI) stop recording `prompt_tokens = 0`.

- `parse_usage_from_message_delta` now prefers `message_delta.usage.input_tokens` when present and non-zero, falling back to the value captured at `message_start`.
- The `message_start` capture is untouched — api.anthropic.com relies on it.
- The two values are never summed: whichever is authoritative is used whole.

## Why

`AnthropicEventProcessor` captured `input_tokens` only from `message_start`. api.anthropic.com populates that field, so the bug never surfaced against Anthropic proper — but Z.AI sends `input_tokens: 0` there and the real count in `message_delta`, which was never read.

Effect on production (`ferrox:0.6.1`): **100% of GLM/Z.AI streaming traffic** was recorded with zero input tokens in `ferrox_tokens_total{type="prompt"}`, the `usage_log` table, Redis budget counters, and the `anthropic_request_completed` log line. GLM input was effectively unbilled and unbudgeted.

## How

Single-function change in `ferrox/src/providers/anthropic_events.rs`:

```rust
let input = v
    .pointer("/usage/input_tokens")
    .and_then(|t| t.as_u64())
    .map(|t| t as u32)
    .filter(|&t| t > 0)
    .unwrap_or(input_tokens);
```

`output_tokens` stays the `?` short-circuit, so a delta without output still yields `None`. The streaming hot path keeps its allocation-free shape — one extra `Value::pointer` lookup per `message_delta`, of which there is exactly one per stream.

This mirrors an idiom the codebase already uses on the outbound side: `anthropic_types.rs:745` guards its own accumulation with `if usage.prompt_tokens > 0`, and `anthropic_types.rs:999` documents that Anthropic clients read the authoritative `input_tokens` from `message_delta`. This change aligns the inbound path with that same assumption.

The doc comments on the `input_tokens` field and on `parse_usage_from_message_delta` were updated — the old wording asserted input tokens arrive *only* in `message_start`, which is what made this bug invisible.

## Acceptance criteria

- [x] A `message_delta` carrying `usage.input_tokens: 47` yields `prompt_tokens == 47` even when `message_start` reported `0` — `message_delta_input_tokens_override_zero_start`
- [x] A `message_start` carrying `input_tokens: 123` with no `input_tokens` in `message_delta` still yields `123` — existing `message_start_input_tokens_flow_into_final_usage`, unmodified and passing
- [x] A `message_delta` reporting `input_tokens: 0` does not clobber a non-zero `message_start` value — `message_delta_zero_input_keeps_message_start`
- [x] `total_tokens` stays `prompt + completion` in all three cases — asserted in each test
- [x] New unit tests in the `anthropic_events.rs` test module cover all three orderings

## Testing

`cargo test --workspace -- --test-threads=1` — 285 + 105 passing, 0 failures. Also verified locally: `cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings`, `cargo build --release --workspace`.

## Out of scope

Cache token counters (`cache_read_input_tokens` / `cache_creation_input_tokens`) — those are #125, which extends the same function.

## Deviations

None. The refined HOW was revalidated against `main` @ `ce6d6fa` and implemented as specified.
