### PR TITLE
feat(anthropic): surface prompt-cache token counters end-to-end

### DIFF
--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -246,11 +246,51 @@ event: content_block_stop
 data: {"type":"content_block_stop","index":0}
 
 event: message_delta
-data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":10}}
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":15,"output_tokens":10}}
 
 event: message_stop
 data: {"type":"message_stop"}
 ```
+
+### Prompt-cache token counters
+
+When an upstream provider reports prompt-cache usage, Ferrox passes the counters
+through on both API surfaces. They are **omitted entirely** when the upstream
+does not report them, so responses from non-caching providers are unchanged.
+
+On `/anthropic/v1/messages` they appear under their native names, in both the
+non-streaming `usage` object and the streaming `message_delta`:
+
+```json
+"usage": {
+  "input_tokens": 47,
+  "output_tokens": 2,
+  "cache_creation_input_tokens": 100,
+  "cache_read_input_tokens": 3968
+}
+```
+
+On `/v1/chat/completions` cache reads appear in OpenAI's canonical form, and the
+native Anthropic keys are preserved alongside them:
+
+```json
+"usage": {
+  "prompt_tokens": 47,
+  "completion_tokens": 2,
+  "total_tokens": 49,
+  "prompt_tokens_details": {"cached_tokens": 3968},
+  "cache_read_input_tokens": 3968,
+  "cache_creation_input_tokens": 100
+}
+```
+
+> `prompt_tokens_details.cached_tokens` and `cache_read_input_tokens` describe
+> **the same tokens** in two vocabularies. Read one or the other — never sum
+> them. Cache *creation* has no OpenAI equivalent and is reported only under its
+> native key.
+
+Note that `input_tokens` / `prompt_tokens` counts the **non-cached** input for
+that request; cached tokens are reported separately in the fields above.
 
 ### Stop reason mapping
 

--- a/ferrox/src/anthropic_types.rs
+++ b/ferrox/src/anthropic_types.rs
@@ -159,6 +159,13 @@ pub enum AnthropicResponseContent {
 pub struct AnthropicUsage {
     pub input_tokens: u32,
     pub output_tokens: u32,
+    /// Prompt-cache counters, omitted entirely when the upstream did not report
+    /// them so a non-caching response stays byte-identical to one from before
+    /// cache support existed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_read_input_tokens: Option<u32>,
 }
 
 // ── Models list response ─────────────────────────────────────────────────────
@@ -581,6 +588,12 @@ pub fn to_anthropic_response(resp: ChatCompletionResponse) -> AnthropicMessagesR
 
     let id = format!("msg_{}", resp.id.trim_start_matches("chatcmpl-"));
 
+    let (cache_creation, cache_read) = resp
+        .usage
+        .as_ref()
+        .map(|u| crate::types::cache_tokens_from_extra(&u.extra))
+        .unwrap_or((None, None));
+
     AnthropicMessagesResponse {
         id,
         response_type: "message".to_string(),
@@ -596,6 +609,8 @@ pub fn to_anthropic_response(resp: ChatCompletionResponse) -> AnthropicMessagesR
                 .as_ref()
                 .map(|u| u.completion_tokens)
                 .unwrap_or(0),
+            cache_creation_input_tokens: cache_creation,
+            cache_read_input_tokens: cache_read,
         },
     }
 }
@@ -626,6 +641,10 @@ struct StreamState {
     /// chunk's usage (via `stream_options.include_usage`), so we capture it
     /// whenever a chunk carries usage and emit it in `message_delta`.
     input_tokens: u32,
+    /// Prompt-cache counters recovered from the chunk usage's `extra`, emitted
+    /// alongside `input_tokens` in `message_delta` when present.
+    cache_creation_input_tokens: Option<u32>,
+    cache_read_input_tokens: Option<u32>,
     stop_reason: String,
     stream_done: bool,
     /// Whether the text content_block (index 0) has been opened.
@@ -673,6 +692,8 @@ pub fn openai_stream_to_anthropic_sse(
         pending: VecDeque::new(),
         output_tokens: 0,
         input_tokens: 0,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
         stop_reason: "end_turn".to_string(),
         stream_done: false,
         text_block_started: false,
@@ -726,6 +747,8 @@ pub fn openai_stream_to_anthropic_sse(
                         &s.stop_reason,
                         s.input_tokens,
                         s.output_tokens,
+                        s.cache_creation_input_tokens,
+                        s.cache_read_input_tokens,
                     )));
                     s.pending.push_back(Ok(make_message_stop_event()));
                     // Loop back to drain pending
@@ -744,6 +767,10 @@ pub fn openai_stream_to_anthropic_sse(
                         if usage.prompt_tokens > 0 {
                             s.input_tokens = usage.prompt_tokens;
                         }
+                        let (creation, read) = crate::types::cache_tokens_from_extra(&usage.extra);
+                        // Keep the last chunk that actually reported each counter.
+                        s.cache_creation_input_tokens = creation.or(s.cache_creation_input_tokens);
+                        s.cache_read_input_tokens = read.or(s.cache_read_input_tokens);
                     }
                     if let Some(choice) = chunk.choices.first() {
                         if let Some(reason) = &choice.finish_reason {
@@ -995,16 +1022,36 @@ fn make_content_block_stop_event(index: u32) -> Event {
         .data(serde_json::json!({"type": "content_block_stop", "index": index}).to_string())
 }
 
-fn make_message_delta_event(stop_reason: &str, input_tokens: u32, output_tokens: u32) -> Event {
+fn make_message_delta_event(
+    stop_reason: &str,
+    input_tokens: u32,
+    output_tokens: u32,
+    cache_creation_input_tokens: Option<u32>,
+    cache_read_input_tokens: Option<u32>,
+) -> Event {
     // Anthropic clients read the authoritative `input_tokens` from `message_delta`
     // (message_start only carries a placeholder), so surface it here.
+    let mut usage = serde_json::json!({
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+    });
+    // Only present when the upstream reported them, so a non-caching stream is
+    // byte-identical to one from before cache support existed.
+    if let Some(map) = usage.as_object_mut() {
+        if let Some(creation) = cache_creation_input_tokens {
+            map.insert("cache_creation_input_tokens".to_string(), creation.into());
+        }
+        if let Some(read) = cache_read_input_tokens {
+            map.insert("cache_read_input_tokens".to_string(), read.into());
+        }
+    }
     let data = serde_json::json!({
         "type": "message_delta",
         "delta": {
             "stop_reason": stop_reason,
             "stop_sequence": null
         },
-        "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens}
+        "usage": usage
     });
     Event::default()
         .event("message_delta")
@@ -2155,6 +2202,103 @@ mod tests {
             "message_delta must carry input_tokens: {dump}"
         );
         assert!(dump.contains(r#"output_tokens\":45"#));
+    }
+
+    #[tokio::test]
+    async fn message_delta_includes_cache_counters_from_usage_extra() {
+        let mut usage_chunk = make_chunk(None, Some("stop"));
+        usage_chunk.usage = Some(crate::types::Usage {
+            prompt_tokens: 47,
+            completion_tokens: 2,
+            total_tokens: 49,
+            extra: crate::types::cache_usage_extra(Some(100), Some(3968)),
+        });
+        let chunks: Vec<Result<ChatCompletionChunk, ProxyError>> = vec![Ok(usage_chunk)];
+        let inner: ProviderStream = Box::pin(futures::stream::iter(chunks));
+
+        let events: Vec<_> =
+            openai_stream_to_anthropic_sse("m".to_string(), "msg_c".to_string(), inner)
+                .collect()
+                .await;
+        let dump = events
+            .iter()
+            .map(|e| format!("{:?}", e.as_ref().unwrap()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            dump.contains(r#"cache_read_input_tokens\":3968"#),
+            "message_delta must carry cache_read_input_tokens: {dump}"
+        );
+        assert!(
+            dump.contains(r#"cache_creation_input_tokens\":100"#),
+            "message_delta must carry cache_creation_input_tokens: {dump}"
+        );
+    }
+
+    #[tokio::test]
+    async fn message_delta_omits_cache_counters_when_absent() {
+        let mut usage_chunk = make_chunk(None, Some("stop"));
+        usage_chunk.usage = Some(crate::types::Usage {
+            prompt_tokens: 123,
+            completion_tokens: 45,
+            total_tokens: 168,
+            extra: Default::default(),
+        });
+        let chunks: Vec<Result<ChatCompletionChunk, ProxyError>> = vec![Ok(usage_chunk)];
+        let inner: ProviderStream = Box::pin(futures::stream::iter(chunks));
+
+        let events: Vec<_> =
+            openai_stream_to_anthropic_sse("m".to_string(), "msg_n".to_string(), inner)
+                .collect()
+                .await;
+        let dump = events
+            .iter()
+            .map(|e| format!("{:?}", e.as_ref().unwrap()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !dump.contains("cache_read_input_tokens") && !dump.contains("cache_creation"),
+            "a non-caching stream must emit no cache keys: {dump}"
+        );
+    }
+
+    #[test]
+    fn response_usage_round_trips_cache_counters() {
+        let mut resp = make_openai_response("x", "stop");
+        resp.usage.as_mut().unwrap().extra = crate::types::cache_usage_extra(Some(100), Some(3968));
+        let r = to_anthropic_response(resp);
+        assert_eq!(r.usage.cache_read_input_tokens, Some(3968));
+        assert_eq!(r.usage.cache_creation_input_tokens, Some(100));
+        let json = serde_json::to_string(&r.usage).unwrap();
+        assert!(json.contains(r#""cache_read_input_tokens":3968"#), "{json}");
+        assert!(
+            json.contains(r#""cache_creation_input_tokens":100"#),
+            "{json}"
+        );
+    }
+
+    #[test]
+    fn response_usage_round_trips_openai_cached_tokens() {
+        // Usage that only speaks OpenAI (prompt_tokens_details.cached_tokens)
+        // must still surface on the Anthropic-native surface.
+        let mut resp = make_openai_response("x", "stop");
+        resp.usage.as_mut().unwrap().extra = std::collections::HashMap::from([(
+            "prompt_tokens_details".to_string(),
+            serde_json::json!({"cached_tokens": 512}),
+        )]);
+        let r = to_anthropic_response(resp);
+        assert_eq!(r.usage.cache_read_input_tokens, Some(512));
+        assert_eq!(r.usage.cache_creation_input_tokens, None);
+    }
+
+    #[test]
+    fn response_usage_without_cache_serializes_unchanged() {
+        // Byte-identical to the pre-cache-support wire format.
+        let r = to_anthropic_response(make_openai_response("x", "stop"));
+        assert_eq!(
+            serde_json::to_string(&r.usage).unwrap(),
+            r#"{"input_tokens":10,"output_tokens":5}"#
+        );
     }
 
     #[tokio::test]

--- a/ferrox/src/providers/anthropic.rs
+++ b/ferrox/src/providers/anthropic.rs
@@ -503,6 +503,12 @@ enum AnthropicResponseContent {
 struct AnthropicUsage {
     input_tokens: u32,
     output_tokens: u32,
+    /// Prompt-cache counters. Absent on upstreams that do not support caching,
+    /// so both are optional and default to `None`.
+    #[serde(default)]
+    cache_creation_input_tokens: Option<u32>,
+    #[serde(default)]
+    cache_read_input_tokens: Option<u32>,
 }
 
 fn anthropic_to_openai_response(resp: AnthropicResponse, model_id: &str) -> ChatCompletionResponse {
@@ -566,7 +572,10 @@ fn anthropic_to_openai_response(resp: AnthropicResponse, model_id: &str) -> Chat
         prompt_tokens: u.input_tokens,
         completion_tokens: u.output_tokens,
         total_tokens: u.input_tokens + u.output_tokens,
-        extra: Default::default(),
+        extra: crate::types::cache_usage_extra(
+            u.cache_creation_input_tokens,
+            u.cache_read_input_tokens,
+        ),
     });
 
     ChatCompletionResponse {
@@ -644,6 +653,47 @@ mod tests {
         assert!(
             matches!(&msg.content, Some(crate::types::MessageContent::Text(t)) if t == "answer")
         );
+    }
+
+    #[test]
+    fn cache_counters_land_in_usage_extra() {
+        let json = r#"{"id":"m","model":"glm","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":47,"output_tokens":2,"cache_creation_input_tokens":100,"cache_read_input_tokens":3968}}"#;
+        let resp: AnthropicResponse = serde_json::from_str(json).unwrap();
+        let out = anthropic_to_openai_response(resp, "glm");
+        let usage = out.usage.expect("usage must be present");
+        assert_eq!(usage.prompt_tokens, 47);
+        assert_eq!(usage.extra["cache_read_input_tokens"], 3968);
+        assert_eq!(usage.extra["cache_creation_input_tokens"], 100);
+        // OpenAI-canonical view of the same cache reads.
+        assert_eq!(usage.extra["prompt_tokens_details"]["cached_tokens"], 3968);
+    }
+
+    #[test]
+    fn absent_cache_counters_leave_usage_extra_empty() {
+        // A non-caching upstream must serialize exactly as it did before cache
+        // support existed — no null or zero-valued keys.
+        let json = r#"{"id":"m","model":"glm","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":5,"output_tokens":3}}"#;
+        let resp: AnthropicResponse = serde_json::from_str(json).unwrap();
+        let out = anthropic_to_openai_response(resp, "glm");
+        let usage = out.usage.expect("usage must be present");
+        assert!(
+            usage.extra.is_empty(),
+            "no cache fields upstream must mean no extra keys: {:?}",
+            usage.extra
+        );
+        assert_eq!(
+            serde_json::to_string(&usage).unwrap(),
+            r#"{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}"#
+        );
+    }
+
+    #[test]
+    fn cache_read_only_omits_creation_key() {
+        let json = r#"{"id":"m","model":"glm","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":47,"output_tokens":2,"cache_read_input_tokens":3968}}"#;
+        let resp: AnthropicResponse = serde_json::from_str(json).unwrap();
+        let usage = anthropic_to_openai_response(resp, "glm").usage.unwrap();
+        assert_eq!(usage.extra["cache_read_input_tokens"], 3968);
+        assert!(!usage.extra.contains_key("cache_creation_input_tokens"));
     }
 
     #[test]

--- a/ferrox/src/providers/anthropic_events.rs
+++ b/ferrox/src/providers/anthropic_events.rs
@@ -25,6 +25,10 @@ pub struct AnthropicEventProcessor {
     /// `input_tokens: 0` in `message_start` and the real count in the trailing
     /// `message_delta`, which takes precedence when non-zero.
     input_tokens: u32,
+    /// Prompt-cache counters captured at `message_start`. Like `input_tokens`,
+    /// a value present on the trailing `message_delta` takes precedence.
+    cache_creation_input_tokens: Option<u32>,
+    cache_read_input_tokens: Option<u32>,
 }
 
 impl AnthropicEventProcessor {
@@ -37,6 +41,8 @@ impl AnthropicEventProcessor {
             stop_reason: None,
             usage: None,
             input_tokens: 0,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
         }
     }
 
@@ -72,6 +78,12 @@ impl AnthropicEventProcessor {
                 {
                     self.input_tokens = input as u32;
                 }
+                // api.anthropic.com reports the cache counters here; Z.AI/GLM
+                // report them on the trailing `message_delta` instead.
+                self.cache_creation_input_tokens =
+                    read_u32(&v, "/message/usage/cache_creation_input_tokens");
+                self.cache_read_input_tokens =
+                    read_u32(&v, "/message/usage/cache_read_input_tokens");
             }
             "content_block_start" => {
                 if v.pointer("/content_block/type").and_then(|t| t.as_str()) == Some("tool_use") {
@@ -160,7 +172,7 @@ impl AnthropicEventProcessor {
                     .pointer("/delta/stop_reason")
                     .and_then(|r| r.as_str())
                     .map(map_stop_reason);
-                self.usage = parse_usage_from_message_delta(&v, self.input_tokens);
+                self.usage = self.usage_from_message_delta(&v);
             }
             "message_stop" => {
                 results.push(Ok(make_final_chunk(
@@ -187,6 +199,29 @@ impl AnthropicEventProcessor {
 
         results
     }
+
+    /// Build the final usage from the trailing `message_delta`.
+    ///
+    /// Values captured at `message_start` are the fallback; anything the delta
+    /// itself reports wins, because some Anthropic-protocol upstreams (Z.AI/GLM)
+    /// only populate usage there. Counters are never summed across the two
+    /// events — whichever source is authoritative is used whole.
+    fn usage_from_message_delta(&self, v: &Value) -> Option<Usage> {
+        let output = v.pointer("/usage/output_tokens").and_then(|t| t.as_u64())? as u32;
+        let input = read_u32(v, "/usage/input_tokens")
+            .filter(|&t| t > 0)
+            .unwrap_or(self.input_tokens);
+        let cache_creation =
+            read_u32(v, "/usage/cache_creation_input_tokens").or(self.cache_creation_input_tokens);
+        let cache_read =
+            read_u32(v, "/usage/cache_read_input_tokens").or(self.cache_read_input_tokens);
+        Some(Usage {
+            prompt_tokens: input,
+            completion_tokens: output,
+            total_tokens: input + output,
+            extra: crate::types::cache_usage_extra(cache_creation, cache_read),
+        })
+    }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -201,26 +236,11 @@ pub fn map_stop_reason(r: &str) -> String {
     }
 }
 
-/// Build the final usage from the trailing `message_delta`.
-///
-/// `input_tokens` is the value captured at `message_start`. A non-zero
-/// `usage.input_tokens` on the delta itself wins — some Anthropic-protocol
-/// upstreams (Z.AI/GLM) only report prompt tokens there. The two values are
-/// never summed: whichever is authoritative is used whole.
-fn parse_usage_from_message_delta(v: &Value, input_tokens: u32) -> Option<Usage> {
-    let output = v.pointer("/usage/output_tokens").and_then(|t| t.as_u64())? as u32;
-    let input = v
-        .pointer("/usage/input_tokens")
+/// Read an unsigned token count at `pointer`, if present.
+fn read_u32(v: &Value, pointer: &str) -> Option<u32> {
+    v.pointer(pointer)
         .and_then(|t| t.as_u64())
         .map(|t| t as u32)
-        .filter(|&t| t > 0)
-        .unwrap_or(input_tokens);
-    Some(Usage {
-        prompt_tokens: input,
-        completion_tokens: output,
-        total_tokens: input + output,
-        extra: Default::default(),
-    })
 }
 
 pub fn make_text_chunk(id: &str, model: &str, text: String) -> ChatCompletionChunk {
@@ -523,6 +543,64 @@ mod tests {
         );
         assert_eq!(usage.completion_tokens, 7);
         assert_eq!(usage.total_tokens, 130);
+    }
+
+    #[test]
+    fn cache_counters_from_message_start_only() {
+        // api.anthropic.com shape: cache counters arrive with message_start.
+        let mut p = make_processor();
+        let start = r#"{"type":"message_start","message":{"id":"m","usage":{"input_tokens":47,"cache_creation_input_tokens":100,"cache_read_input_tokens":3968}}}"#;
+        p.process("message_start", start, "claude-3", "anthropic");
+        let delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}"#;
+        p.process("message_delta", delta, "claude-3", "anthropic");
+        let usage = p.usage.as_ref().unwrap();
+        assert_eq!(usage.prompt_tokens, 47);
+        assert_eq!(usage.extra["cache_read_input_tokens"], 3968);
+        assert_eq!(usage.extra["cache_creation_input_tokens"], 100);
+        assert_eq!(usage.extra["prompt_tokens_details"]["cached_tokens"], 3968);
+    }
+
+    #[test]
+    fn cache_counters_from_message_delta_only() {
+        // Z.AI/GLM shape: message_start is empty, everything lands on the delta.
+        let mut p = make_processor();
+        let start = r#"{"type":"message_start","message":{"id":"m","usage":{"input_tokens":0}}}"#;
+        p.process("message_start", start, "glm-4.5-air", "zai");
+        let delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":47,"output_tokens":2,"cache_read_input_tokens":3968}}"#;
+        p.process("message_delta", delta, "glm-4.5-air", "zai");
+        let usage = p.usage.as_ref().unwrap();
+        assert_eq!(usage.prompt_tokens, 47);
+        assert_eq!(usage.extra["cache_read_input_tokens"], 3968);
+        assert!(!usage.extra.contains_key("cache_creation_input_tokens"));
+    }
+
+    #[test]
+    fn message_delta_cache_counters_win_over_message_start() {
+        let mut p = make_processor();
+        let start = r#"{"type":"message_start","message":{"id":"m","usage":{"input_tokens":47,"cache_read_input_tokens":10}}}"#;
+        p.process("message_start", start, "claude-3", "anthropic");
+        let delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2,"cache_read_input_tokens":3968}}"#;
+        p.process("message_delta", delta, "claude-3", "anthropic");
+        let usage = p.usage.as_ref().unwrap();
+        assert_eq!(
+            usage.extra["cache_read_input_tokens"], 3968,
+            "the delta's counter must win, never be summed with message_start's"
+        );
+    }
+
+    #[test]
+    fn no_cache_counters_leaves_usage_extra_empty() {
+        let mut p = make_processor();
+        let start = r#"{"type":"message_start","message":{"id":"m","usage":{"input_tokens":123}}}"#;
+        p.process("message_start", start, "claude-3", "anthropic");
+        let delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}"#;
+        p.process("message_delta", delta, "claude-3", "anthropic");
+        let usage = p.usage.as_ref().unwrap();
+        assert!(
+            usage.extra.is_empty(),
+            "a non-caching stream must carry no extra keys: {:?}",
+            usage.extra
+        );
     }
 
     #[test]

--- a/ferrox/src/types.rs
+++ b/ferrox/src/types.rs
@@ -212,6 +212,69 @@ pub struct Usage {
     pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
+// ── Prompt-cache token counters carried in `Usage.extra` ─────────────────────
+
+/// Anthropic-native key for tokens written to the prompt cache.
+pub const CACHE_CREATION_INPUT_TOKENS: &str = "cache_creation_input_tokens";
+/// Anthropic-native key for tokens served from the prompt cache.
+pub const CACHE_READ_INPUT_TOKENS: &str = "cache_read_input_tokens";
+/// OpenAI-canonical container for input-token breakdowns.
+pub const PROMPT_TOKENS_DETAILS: &str = "prompt_tokens_details";
+/// OpenAI-canonical key for cache reads, nested under [`PROMPT_TOKENS_DETAILS`].
+pub const CACHED_TOKENS: &str = "cached_tokens";
+
+/// Build the [`Usage::extra`] entries for a pair of prompt-cache counters.
+///
+/// Cache **reads** are represented twice on purpose: once under the
+/// Anthropic-native `cache_read_input_tokens` key and once as OpenAI's
+/// `prompt_tokens_details.cached_tokens`, so both API surfaces report them
+/// without a second translation step. **They are the same tokens — a consumer
+/// must read exactly one of the two and never sum them.** Cache *creation* has
+/// no OpenAI equivalent and is emitted only under its native key.
+///
+/// Returns an empty map when neither counter is present, which keeps the
+/// no-cache path allocation-free (`HashMap::new` does not allocate) and makes
+/// the serialized response byte-identical to one without cache support.
+pub fn cache_usage_extra(
+    creation: Option<u32>,
+    read: Option<u32>,
+) -> HashMap<String, serde_json::Value> {
+    let mut extra = HashMap::new();
+    if let Some(creation) = creation {
+        extra.insert(CACHE_CREATION_INPUT_TOKENS.to_string(), creation.into());
+    }
+    if let Some(read) = read {
+        extra.insert(CACHE_READ_INPUT_TOKENS.to_string(), read.into());
+        extra.insert(
+            PROMPT_TOKENS_DETAILS.to_string(),
+            serde_json::json!({ CACHED_TOKENS: read }),
+        );
+    }
+    extra
+}
+
+/// Recover `(cache_creation, cache_read)` from [`Usage::extra`].
+///
+/// The Anthropic-native keys win; `prompt_tokens_details.cached_tokens` is the
+/// fallback for reads so usage that originated from an OpenAI-format upstream
+/// still round-trips onto the Anthropic surface.
+pub fn cache_tokens_from_extra(
+    extra: &HashMap<String, serde_json::Value>,
+) -> (Option<u32>, Option<u32>) {
+    let as_u32 = |v: &serde_json::Value| v.as_u64().map(|t| t as u32);
+    let creation = extra.get(CACHE_CREATION_INPUT_TOKENS).and_then(as_u32);
+    let read = extra
+        .get(CACHE_READ_INPUT_TOKENS)
+        .and_then(as_u32)
+        .or_else(|| {
+            extra
+                .get(PROMPT_TOKENS_DETAILS)
+                .and_then(|d| d.get(CACHED_TOKENS))
+                .and_then(as_u32)
+        });
+    (creation, read)
+}
+
 // ── Streaming chunk ──────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Closes #125

## What

Plumb Anthropic prompt-cache token counters (`cache_read_input_tokens`, `cache_creation_input_tokens`) end-to-end — deserialize them from the upstream, carry them losslessly through the internal OpenAI representation via `Usage.extra`, and re-emit them on both the Anthropic-native and OpenAI-format surfaces.

## Why

Prompt caching already worked through Ferrox for `type: anthropic` providers — `cache_control` reaches the upstream — but Ferrox erased the proof. Three typed structs modelled only input/output tokens, so the counters died at parse or serialize time, and `anthropic_to_openai_response` hard-coded `extra: Default::default()`.

Clients (Claude Code above all) could not distinguish a cache hit from a miss, and a request that consumed 4015 input tokens was recorded as 47.

## How

`types::Usage.extra` is the single lossless carrier — already flattened and `skip_serializing_if`-guarded, so it costs nothing on the wire when empty.

**Deserialize side**
- `providers/anthropic.rs` — `AnthropicUsage` gains both counters as `#[serde(default)] Option<u32>`; `anthropic_to_openai_response` populates `extra` from them.
- `providers/anthropic_events.rs` — the streaming processor captures both at `message_start` and prefers whatever the trailing `message_delta` reports. `parse_usage_from_message_delta` became a method (`usage_from_message_delta`) since it now reads three pieces of processor state; a small `read_u32` helper replaces the repeated pointer/`as_u64`/`as u32` chain.

**Serialize side**
- `anthropic_types.rs` — the outbound `AnthropicUsage` gains both fields with `skip_serializing_if = "Option::is_none"`; `to_anthropic_response` and the SSE `message_delta` writer read them back out of `Usage.extra`.

**The key contract, defined once**
`types.rs` gains `cache_usage_extra()` / `cache_tokens_from_extra()` plus the four key constants. Both directions go through the same pair, so the two adapters cannot drift apart — the risk the issue flagged.

Cache **reads** are represented twice on purpose: the Anthropic-native key and OpenAI's `prompt_tokens_details.cached_tokens`. They are the same tokens in two vocabularies — documented in the helper and in `api-reference.md` — and a consumer must read one, never sum both.

## Acceptance criteria

- [x] Non-streaming `/anthropic/v1/messages` returns both counters when the upstream reports them — `response_usage_round_trips_cache_counters`
- [x] Streaming `message_delta` carries the same fields — `message_delta_includes_cache_counters_from_usage_extra`
- [x] `/v1/chat/completions` reports cache reads as `prompt_tokens_details.cached_tokens` — `cache_counters_land_in_usage_extra`
- [x] Absent upstream cache fields, the response is byte-identical to today — asserted on the **exact JSON string** in `response_usage_without_cache_serializes_unchanged` and `absent_cache_counters_leave_usage_extra_empty`
- [x] Round-trip unit tests for both the response and the SSE path — 12 new tests

## Testing

`cargo test --workspace -- --test-threads=1` — 297 + 105 passing (12 new), 0 failures. Also `cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings`, `cargo build --release --workspace`.

New coverage includes both provider shapes: counters arriving on `message_start` (api.anthropic.com) and on `message_delta` only (Z.AI/GLM), plus the precedence case and the no-cache case on each path.

## Deviations from the refined HOW

1. **Helper placement** — the HOW put `cache_usage_extra` in `providers/anthropic.rs`. It lives in `types.rs` instead, next to `Usage`: the read-back side is in `anthropic_types.rs` (outside `providers/`), and having a top-level module depend on a provider adapter would invert the layering. `types.rs` is what owns the `Usage.extra` contract.
2. **`#[serde(default)]` on the outbound struct** — omitted, because `anthropic_types::AnthropicUsage` derives only `Serialize`, where the attribute is inert. `skip_serializing_if` alone carries the requirement.
3. **Stale doc example fixed** — `api-reference.md`'s `message_delta` example omitted `input_tokens`, which the code already emitted. Corrected in the same block that gained the cache-counter docs.

## Note for #126

`prompt_tokens` remains Anthropic's **non-cached** input count; cached tokens are reported separately, not folded in. #126 must decide deliberately whether metrics and `usage_log` sum them, and must read either `cache_read_input_tokens` **or** `prompt_tokens_details.cached_tokens` — never both, or cache reads double-count.

## Out of scope

Metrics/logs/DB surfacing (#126), request-side `cache_control` (#127), Bedrock (#128), and any pricing or budget weighting of cached tokens.
