### PR TITLE
feat(observability): expose prompt-cache token stats in metrics, logs and usage_log

### DIFF
--- a/docs/user/observability.md
+++ b/docs/user/observability.md
@@ -28,9 +28,15 @@ Every completed request emits a structured log line at `info` level:
   "status": 200,
   "latency_ms": 843,
   "prompt_tokens": 45,
-  "completion_tokens": 120
+  "completion_tokens": 120,
+  "cache_read_tokens": 3968,
+  "cache_write_tokens": 100
 }
 ```
+
+`cache_read_tokens` and `cache_write_tokens` are prompt-cache counters. They are
+**omitted entirely** when the provider reported no cache usage, so requests
+against non-caching providers log exactly as before.
 
 ---
 
@@ -58,9 +64,37 @@ When `path` is set, metrics are served only at that path.
 | `ferrox_requests_total` | Counter | `provider`, `model_alias`, `model_id`, `status`, `key_name` | Total requests dispatched |
 | `ferrox_request_duration_seconds` | Histogram | `provider`, `model_alias`, `status` | End-to-end latency |
 | `ferrox_ttfb_seconds` | Histogram | `provider`, `model_alias` | Time to first byte |
-| `ferrox_tokens_total` | Counter | `provider`, `model_alias`, `key_name`, `type` | Tokens processed per client (`type`: `prompt` or `completion`) |
+| `ferrox_tokens_total` | Counter | `provider`, `model_alias`, `key_name`, `type` | Tokens processed per client (`type`: `prompt`, `completion`, `cache_read`, `cache_write`) |
 | `ferrox_active_streams` | Gauge | `provider`, `model_alias` | Active SSE connections |
 | `ferrox_errors_total` | Counter | `provider`, `error_type` | Errors by type |
+
+### Prompt-cache metrics
+
+Providers that support prompt caching report two extra `type` values on
+`ferrox_tokens_total`:
+
+| `type` | Meaning |
+|---|---|
+| `cache_read` | Tokens served from the prompt cache (Anthropic `cache_read_input_tokens`, Bedrock `cacheReadInputTokens`) |
+| `cache_write` | Tokens written to the prompt cache (Anthropic `cache_creation_input_tokens`, Bedrock `cacheWriteInputTokens`) |
+
+These series are created **only when a provider actually reports cache usage**,
+so enabling this costs no cardinality on non-caching routes.
+
+`prompt` counts the **non-cached** input tokens for a request — cache reads are
+counted separately, not folded into `prompt`. Cache hit rate is therefore the
+share of total input that was served from cache:
+
+```promql
+sum(rate(ferrox_tokens_total{type="cache_read"}[5m]))
+/
+sum(rate(ferrox_tokens_total{type=~"prompt|cache_read"}[5m]))
+```
+
+Break it down per model, client or provider by adding a `by` clause — e.g.
+`by (model_alias)` on both halves. A sudden drop in this ratio is the signal
+that caching has regressed (a changed system prompt, a lost cache breakpoint, or
+a failover to a provider that does not cache).
 
 ### Routing metrics
 

--- a/ferrox-cp/migrations/20240004000000_usage_log_cache_tokens.sql
+++ b/ferrox-cp/migrations/20240004000000_usage_log_cache_tokens.sql
@@ -1,0 +1,10 @@
+-- Prompt-cache token counters, reported by providers that support prompt caching
+-- (Anthropic `cache_read_input_tokens` / `cache_creation_input_tokens`, Bedrock
+-- `cacheReadInputTokens` / `cacheWriteInputTokens`).
+--
+-- Nullable with no default and no backfill on purpose: NULL means "written by a
+-- gateway that predates cache accounting", which is a different fact from a
+-- recorded 0 ("this provider reported no cache usage for this request").
+ALTER TABLE usage_log
+    ADD COLUMN cache_read_tokens INT,
+    ADD COLUMN cache_write_tokens INT;

--- a/ferrox-cp/src/db/models.rs
+++ b/ferrox-cp/src/db/models.rs
@@ -14,6 +14,10 @@ pub struct UsageRecord {
     pub prompt_tokens: i32,
     pub completion_tokens: i32,
     pub total_tokens: i32,
+    /// Prompt-cache counters. `NULL` on rows written before cache accounting
+    /// existed — distinct from a recorded `0` (provider reported no cache use).
+    pub cache_read_tokens: Option<i32>,
+    pub cache_write_tokens: Option<i32>,
     pub latency_ms: Option<i32>,
     pub created_at: DateTime<Utc>,
 }

--- a/ferrox-cp/src/db/usage_repo.rs
+++ b/ferrox-cp/src/db/usage_repo.rs
@@ -39,15 +39,20 @@ impl<'a> UsageRepository<'a> {
         let prompt_tokens: Vec<i32> = records.iter().map(|r| r.prompt_tokens).collect();
         let completion_tokens: Vec<i32> = records.iter().map(|r| r.completion_tokens).collect();
         let total_tokens: Vec<i32> = records.iter().map(|r| r.total_tokens).collect();
+        let cache_read_tokens: Vec<Option<i32>> =
+            records.iter().map(|r| r.cache_read_tokens).collect();
+        let cache_write_tokens: Vec<Option<i32>> =
+            records.iter().map(|r| r.cache_write_tokens).collect();
         let latency_ms: Vec<Option<i32>> = records.iter().map(|r| r.latency_ms).collect();
 
         sqlx::query(
             r#"
             INSERT INTO usage_log
-                (client_id, request_id, model, provider, prompt_tokens, completion_tokens, total_tokens, latency_ms)
+                (client_id, request_id, model, provider, prompt_tokens, completion_tokens, total_tokens,
+                 cache_read_tokens, cache_write_tokens, latency_ms)
             SELECT * FROM UNNEST(
                 $1::uuid[], $2::text[], $3::text[], $4::text[],
-                $5::int[], $6::int[], $7::int[], $8::int[]
+                $5::int[], $6::int[], $7::int[], $8::int[], $9::int[], $10::int[]
             )
             "#,
         )
@@ -58,6 +63,8 @@ impl<'a> UsageRepository<'a> {
         .bind(&prompt_tokens)
         .bind(&completion_tokens)
         .bind(&total_tokens)
+        .bind(&cache_read_tokens)
+        .bind(&cache_write_tokens)
         .bind(&latency_ms)
         .execute(self.db)
         .await
@@ -110,6 +117,7 @@ impl<'a> UsageRepository<'a> {
             r#"
             SELECT id, client_id, request_id, model, provider,
                    prompt_tokens, completion_tokens, total_tokens,
+                   cache_read_tokens, cache_write_tokens,
                    latency_ms, created_at
             FROM usage_log
             WHERE client_id = $1
@@ -145,6 +153,9 @@ pub struct UsageInsert {
     pub prompt_tokens: i32,
     pub completion_tokens: i32,
     pub total_tokens: i32,
+    /// `None` writes SQL `NULL`, meaning "not recorded" rather than "zero".
+    pub cache_read_tokens: Option<i32>,
+    pub cache_write_tokens: Option<i32>,
     pub latency_ms: Option<i32>,
 }
 
@@ -181,6 +192,8 @@ mod tests {
             prompt_tokens: prompt,
             completion_tokens: completion,
             total_tokens: prompt + completion,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
             latency_ms: Some(150),
         }
     }
@@ -201,6 +214,76 @@ mod tests {
         assert_eq!(summary.total_completion_tokens, 150);
         assert_eq!(summary.total_tokens, 450);
         assert_eq!(summary.request_count, 2);
+    }
+
+    #[sqlx::test(migrator = "crate::MIGRATOR")]
+    async fn insert_batch_round_trips_cache_tokens(pool: sqlx::PgPool) {
+        let cid = create_client(&pool, "cache-tokens").await;
+        let repo = UsageRepository::new(&pool);
+
+        let mut cached = sample_insert(cid, "claude-sonnet", 47, 2);
+        cached.cache_read_tokens = Some(3968);
+        cached.cache_write_tokens = Some(100);
+        // A provider that reports no cache usage records an explicit zero.
+        let mut uncached = sample_insert(cid, "claude-sonnet", 100, 50);
+        uncached.cache_read_tokens = Some(0);
+        uncached.cache_write_tokens = Some(0);
+        // A gateway predating cache accounting records NULL.
+        let legacy = sample_insert(cid, "claude-sonnet", 10, 5);
+
+        repo.insert_batch(&[cached, uncached, legacy])
+            .await
+            .expect("insert ok");
+
+        let rows = repo
+            .list(UsageFilter {
+                client_id: cid,
+                ..Default::default()
+            })
+            .await
+            .expect("list ok");
+        assert_eq!(rows.len(), 3);
+
+        let by_prompt = |p: i32| {
+            rows.iter()
+                .find(|r| r.prompt_tokens == p)
+                .unwrap_or_else(|| panic!("row with prompt_tokens={p}"))
+        };
+        assert_eq!(by_prompt(47).cache_read_tokens, Some(3968));
+        assert_eq!(by_prompt(47).cache_write_tokens, Some(100));
+        assert_eq!(by_prompt(100).cache_read_tokens, Some(0));
+        assert_eq!(
+            by_prompt(10).cache_read_tokens,
+            None,
+            "NULL must stay distinct from a recorded 0"
+        );
+    }
+
+    /// Decided behaviour for a gateway running against an unmigrated database:
+    /// the insert **fails loudly** rather than silently dropping the cache
+    /// columns. The gateway's flush logs the error and drops that batch, so the
+    /// operator sees it; the fix is to deploy the control plane (which applies
+    /// migrations at startup) before the gateway.
+    #[sqlx::test(migrator = "crate::MIGRATOR")]
+    async fn insert_batch_fails_loudly_on_unmigrated_schema(pool: sqlx::PgPool) {
+        sqlx::query(
+            "ALTER TABLE usage_log DROP COLUMN cache_read_tokens, DROP COLUMN cache_write_tokens",
+        )
+        .execute(&pool)
+        .await
+        .expect("simulate pre-migration schema");
+
+        let cid = create_client(&pool, "unmigrated").await;
+        let repo = UsageRepository::new(&pool);
+
+        let err = repo
+            .insert_batch(&[sample_insert(cid, "gpt-4", 100, 50)])
+            .await
+            .expect_err("insert must fail, not silently succeed");
+        assert!(
+            matches!(err, RepoError::Database(_)),
+            "expected a database error naming the missing column, got {err:?}"
+        );
     }
 
     #[sqlx::test(migrator = "crate::MIGRATOR")]

--- a/ferrox-cp/src/handlers/admin/clients.rs
+++ b/ferrox-cp/src/handlers/admin/clients.rs
@@ -788,6 +788,8 @@ mod tests {
                 prompt_tokens: 100,
                 completion_tokens: 50,
                 total_tokens: 150,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
                 latency_ms: Some(200),
             })
             .collect();
@@ -899,6 +901,8 @@ mod tests {
                 prompt_tokens: 100,
                 completion_tokens: 50,
                 total_tokens: 150,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
                 latency_ms: Some(200),
             })
             .collect();

--- a/ferrox/src/handlers/anthropic_messages.rs
+++ b/ferrox/src/handlers/anthropic_messages.rs
@@ -204,26 +204,37 @@ pub async fn anthropic_messages(
                 let accumulated_prompt = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
                 let accumulated_completion =
                     std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+                let accumulated_cache_read =
+                    std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+                let accumulated_cache_write =
+                    std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
                 let acc_p = accumulated_prompt.clone();
                 let acc_c = accumulated_completion.clone();
+                let acc_cr = accumulated_cache_read.clone();
+                let acc_cw = accumulated_cache_write.clone();
 
                 // Wrap the OpenAI-format stream to capture token usage before
                 // converting to Anthropic SSE format.
                 let metered_stream = stream.map(move |chunk_result| {
                     chunk_result.inspect(|chunk| {
                         if let Some(usage) = &chunk.usage {
+                            let (cache_read, cache_write) = crate::types::cache_tokens(usage);
                             metrics::record_tokens(
                                 &p1,
                                 &a1,
                                 &k1,
                                 usage.prompt_tokens,
                                 usage.completion_tokens,
+                                cache_read,
+                                cache_write,
                             );
                             acc_p.store(usage.prompt_tokens, std::sync::atomic::Ordering::Relaxed);
                             acc_c.store(
                                 usage.completion_tokens,
                                 std::sync::atomic::Ordering::Relaxed,
                             );
+                            acc_cr.store(cache_read, std::sync::atomic::Ordering::Relaxed);
+                            acc_cw.store(cache_write, std::sync::atomic::Ordering::Relaxed);
                         }
                     })
                 });
@@ -272,6 +283,10 @@ pub async fn anthropic_messages(
                     let prompt = accumulated_prompt.load(std::sync::atomic::Ordering::Relaxed);
                     let completion =
                         accumulated_completion.load(std::sync::atomic::Ordering::Relaxed);
+                    let cache_read =
+                        accumulated_cache_read.load(std::sync::atomic::Ordering::Relaxed);
+                    let cache_write =
+                        accumulated_cache_write.load(std::sync::atomic::Ordering::Relaxed);
                     if prompt > 0 || completion > 0 {
                         // Push webhook event (before usage_writer moves the strings)
                         event_dispatcher.dispatch(TokenUsageEvent {
@@ -295,6 +310,8 @@ pub async fn anthropic_messages(
                             provider: stream_provider,
                             prompt_tokens: prompt,
                             completion_tokens: completion,
+                            cache_read_tokens: cache_read,
+                            cache_write_tokens: cache_write,
                             latency_ms: Some((latency * 1000.0) as u64),
                         });
 
@@ -322,6 +339,10 @@ pub async fn anthropic_messages(
                         latency_ms = (latency * 1000.0) as u64,
                         prompt_tokens = prompt,
                         completion_tokens = completion,
+                        // `Option` fields are omitted entirely when `None`, so
+                        // quiet (non-caching) paths stay quiet.
+                        cache_read_tokens = (cache_read > 0).then_some(cache_read),
+                        cache_write_tokens = (cache_write > 0).then_some(cache_write),
                         "anthropic_request_completed"
                     );
                     // Return a silent SSE comment; Anthropic SDK ignores it.
@@ -355,12 +376,15 @@ pub async fn anthropic_messages(
         match result {
             Ok((resp, provider_name, model_id)) => {
                 if let Some(usage) = &resp.usage {
+                    let (cache_read, cache_write) = crate::types::cache_tokens(usage);
                     metrics::record_tokens(
                         &provider_name,
                         &model_alias,
                         &ctx.key_name,
                         usage.prompt_tokens,
                         usage.completion_tokens,
+                        cache_read,
+                        cache_write,
                     );
 
                     state.usage_writer.record(UsageEvent {
@@ -370,6 +394,8 @@ pub async fn anthropic_messages(
                         provider: provider_name.clone(),
                         prompt_tokens: usage.prompt_tokens,
                         completion_tokens: usage.completion_tokens,
+                        cache_read_tokens: cache_read,
+                        cache_write_tokens: cache_write,
                         latency_ms: Some((latency * 1000.0) as u64),
                     });
 

--- a/ferrox/src/handlers/chat.rs
+++ b/ferrox/src/handlers/chat.rs
@@ -94,8 +94,14 @@ pub async fn chat_completions(
                 let accumulated_prompt = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
                 let accumulated_completion =
                     std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+                let accumulated_cache_read =
+                    std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+                let accumulated_cache_write =
+                    std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
                 let acc_p = accumulated_prompt.clone();
                 let acc_c = accumulated_completion.clone();
+                let acc_cr = accumulated_cache_read.clone();
+                let acc_cw = accumulated_cache_write.clone();
 
                 let p2 = provider_name.clone();
                 let a2 = alias.clone();
@@ -106,12 +112,15 @@ pub async fn chat_completions(
                     .map(move |chunk_result| {
                         chunk_result.map(|chunk| {
                             if let Some(usage) = &chunk.usage {
+                                let (cache_read, cache_write) = crate::types::cache_tokens(usage);
                                 metrics::record_tokens(
                                     &p1,
                                     &a1,
                                     &k1,
                                     usage.prompt_tokens,
                                     usage.completion_tokens,
+                                    cache_read,
+                                    cache_write,
                                 );
                                 acc_p.store(
                                     usage.prompt_tokens,
@@ -121,6 +130,8 @@ pub async fn chat_completions(
                                     usage.completion_tokens,
                                     std::sync::atomic::Ordering::Relaxed,
                                 );
+                                acc_cr.store(cache_read, std::sync::atomic::Ordering::Relaxed);
+                                acc_cw.store(cache_write, std::sync::atomic::Ordering::Relaxed);
                             }
                             let data = serde_json::to_string(&chunk).unwrap_or_default();
                             Event::default().data(data)
@@ -148,6 +159,10 @@ pub async fn chat_completions(
                         let prompt = accumulated_prompt.load(std::sync::atomic::Ordering::Relaxed);
                         let completion =
                             accumulated_completion.load(std::sync::atomic::Ordering::Relaxed);
+                        let cache_read =
+                            accumulated_cache_read.load(std::sync::atomic::Ordering::Relaxed);
+                        let cache_write =
+                            accumulated_cache_write.load(std::sync::atomic::Ordering::Relaxed);
                         if prompt > 0 || completion > 0 {
                             // Push webhook event (clone before usage_writer moves the strings)
                             event_dispatcher.dispatch(TokenUsageEvent {
@@ -171,6 +186,8 @@ pub async fn chat_completions(
                                 provider: stream_provider,
                                 prompt_tokens: prompt,
                                 completion_tokens: completion,
+                                cache_read_tokens: cache_read,
+                                cache_write_tokens: cache_write,
                                 latency_ms: Some((latency * 1000.0) as u64),
                             });
 
@@ -196,6 +213,10 @@ pub async fn chat_completions(
                             streaming = true,
                             status = 200,
                             latency_ms = (latency * 1000.0) as u64,
+                            // `Option` fields are omitted entirely when `None`,
+                            // so quiet (non-caching) paths stay quiet.
+                            cache_read_tokens = (cache_read > 0).then_some(cache_read),
+                            cache_write_tokens = (cache_write > 0).then_some(cache_write),
                             "request_completed"
                         );
                         Ok::<Event, ProxyError>(Event::default().data("[DONE]"))
@@ -218,12 +239,15 @@ pub async fn chat_completions(
             Ok((resp, provider_name, model_id)) => {
                 // Record tokens
                 if let Some(usage) = &resp.usage {
+                    let (cache_read, cache_write) = crate::types::cache_tokens(usage);
                     metrics::record_tokens(
                         &provider_name,
                         &req.model,
                         &ctx.key_name,
                         usage.prompt_tokens,
                         usage.completion_tokens,
+                        cache_read,
+                        cache_write,
                     );
 
                     // Persist usage to database
@@ -234,6 +258,8 @@ pub async fn chat_completions(
                         provider: provider_name.clone(),
                         prompt_tokens: usage.prompt_tokens,
                         completion_tokens: usage.completion_tokens,
+                        cache_read_tokens: cache_read,
+                        cache_write_tokens: cache_write,
                         latency_ms: Some((latency * 1000.0) as u64),
                     });
 

--- a/ferrox/src/telemetry/metrics.rs
+++ b/ferrox/src/telemetry/metrics.rs
@@ -209,12 +209,18 @@ pub fn gather() -> String {
 }
 
 /// Record an observed token usage from a completed request.
+///
+/// `cache_read` / `cache_write` are the prompt-cache counters. They are recorded
+/// only when non-zero, so providers that do not support caching never create the
+/// extra time series — cardinality grows only where there is something to see.
 pub fn record_tokens(
     provider: &str,
     model_alias: &str,
     key_name: &str,
     prompt: u32,
     completion: u32,
+    cache_read: u32,
+    cache_write: u32,
 ) {
     TOKENS_TOTAL
         .with_label_values(&[provider, model_alias, key_name, "prompt"])
@@ -222,4 +228,71 @@ pub fn record_tokens(
     TOKENS_TOTAL
         .with_label_values(&[provider, model_alias, key_name, "completion"])
         .inc_by(completion as f64);
+    if cache_read > 0 {
+        TOKENS_TOTAL
+            .with_label_values(&[provider, model_alias, key_name, "cache_read"])
+            .inc_by(cache_read as f64);
+    }
+    if cache_write > 0 {
+        TOKENS_TOTAL
+            .with_label_values(&[provider, model_alias, key_name, "cache_write"])
+            .inc_by(cache_write as f64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Current value of a `ferrox_tokens_total` series, or `None` if the series
+    /// does not exist at all. The distinction is the point: a zero-valued series
+    /// is still cardinality we do not want to create.
+    ///
+    /// Reads the encoded exposition text rather than the protobuf structs, so
+    /// this asserts on exactly what a Prometheus scrape would see.
+    fn token_series(provider: &str, token_type: &str) -> Option<f64> {
+        let scrape = gather();
+        scrape
+            .lines()
+            .filter(|l| l.starts_with("ferrox_tokens_total{"))
+            .find(|l| {
+                l.contains(&format!(r#"provider="{provider}""#))
+                    && l.contains(&format!(r#"type="{token_type}""#))
+            })
+            .and_then(|l| l.rsplit(' ').next())
+            .and_then(|v| v.parse().ok())
+    }
+
+    #[test]
+    fn zero_cache_tokens_create_no_series() {
+        // Distinct provider label so this test owns its series regardless of
+        // what else ran in the same process.
+        record_tokens("test-nocache", "alias", "key", 10, 5, 0, 0);
+
+        assert_eq!(token_series("test-nocache", "prompt"), Some(10.0));
+        assert_eq!(token_series("test-nocache", "completion"), Some(5.0));
+        assert_eq!(
+            token_series("test-nocache", "cache_read"),
+            None,
+            "a non-caching provider must not create a cache_read series"
+        );
+        assert_eq!(token_series("test-nocache", "cache_write"), None);
+    }
+
+    #[test]
+    fn non_zero_cache_tokens_increment_their_series() {
+        record_tokens("test-cache", "alias", "key", 47, 2, 3968, 100);
+
+        assert_eq!(token_series("test-cache", "prompt"), Some(47.0));
+        assert_eq!(token_series("test-cache", "cache_read"), Some(3968.0));
+        assert_eq!(token_series("test-cache", "cache_write"), Some(100.0));
+    }
+
+    #[test]
+    fn cache_read_alone_does_not_create_a_write_series() {
+        record_tokens("test-readonly", "alias", "key", 47, 2, 3968, 0);
+
+        assert_eq!(token_series("test-readonly", "cache_read"), Some(3968.0));
+        assert_eq!(token_series("test-readonly", "cache_write"), None);
+    }
 }

--- a/ferrox/src/types.rs
+++ b/ferrox/src/types.rs
@@ -253,6 +253,17 @@ pub fn cache_usage_extra(
     extra
 }
 
+/// Prompt-cache counters for a completed response as `(cache_read, cache_write)`,
+/// defaulting to zero when the provider reported none.
+///
+/// The observability surfaces (metrics, logs, `usage_log`) all want plain
+/// counts, and they must all read the **same** one of the two equivalent cache
+/// read representations — this is that single reading.
+pub fn cache_tokens(usage: &Usage) -> (u32, u32) {
+    let (creation, read) = cache_tokens_from_extra(&usage.extra);
+    (read.unwrap_or(0), creation.unwrap_or(0))
+}
+
 /// Recover `(cache_creation, cache_read)` from [`Usage::extra`].
 ///
 /// The Anthropic-native keys win; `prompt_tokens_details.cached_tokens` is the
@@ -485,5 +496,37 @@ mod tests {
             reasoning_content: None,
         });
         assert_eq!(r.system_message(), None);
+    }
+
+    fn usage_with(extra: HashMap<String, serde_json::Value>) -> Usage {
+        Usage {
+            prompt_tokens: 47,
+            completion_tokens: 2,
+            total_tokens: 49,
+            extra,
+        }
+    }
+
+    #[test]
+    fn cache_tokens_returns_read_then_write() {
+        // Note the ordering flip: the carrier is (creation, read), the
+        // observability tuple is (read, write).
+        let usage = usage_with(cache_usage_extra(Some(100), Some(3968)));
+        assert_eq!(cache_tokens(&usage), (3968, 100));
+    }
+
+    #[test]
+    fn cache_tokens_defaults_to_zero() {
+        let usage = usage_with(HashMap::new());
+        assert_eq!(cache_tokens(&usage), (0, 0));
+    }
+
+    #[test]
+    fn cache_tokens_reads_openai_cached_tokens_fallback() {
+        let usage = usage_with(HashMap::from([(
+            "prompt_tokens_details".to_string(),
+            serde_json::json!({"cached_tokens": 512}),
+        )]));
+        assert_eq!(cache_tokens(&usage), (512, 0));
     }
 }

--- a/ferrox/src/usage_writer.rs
+++ b/ferrox/src/usage_writer.rs
@@ -12,6 +12,11 @@ pub struct UsageEvent {
     pub provider: String,
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
+    /// Prompt-cache counters. Zero means "provider reported none"; the column is
+    /// still written, so a `NULL` in `usage_log` means "gateway predates this
+    /// feature" and is distinguishable from a recorded zero.
+    pub cache_read_tokens: u32,
+    pub cache_write_tokens: u32,
     pub latency_ms: Option<u64>,
 }
 
@@ -118,6 +123,8 @@ async fn flush(pool: &sqlx::PgPool, buffer: &mut Vec<UsageEvent>) {
         .iter()
         .map(|e| (e.prompt_tokens + e.completion_tokens) as i32)
         .collect();
+    let cache_read_tokens: Vec<i32> = valid.iter().map(|e| e.cache_read_tokens as i32).collect();
+    let cache_write_tokens: Vec<i32> = valid.iter().map(|e| e.cache_write_tokens as i32).collect();
     let latency_ms: Vec<Option<i32>> = valid
         .iter()
         .map(|e| e.latency_ms.map(|l| l as i32))
@@ -126,10 +133,11 @@ async fn flush(pool: &sqlx::PgPool, buffer: &mut Vec<UsageEvent>) {
     let result = sqlx::query(
         r#"
         INSERT INTO usage_log
-            (client_id, request_id, model, provider, prompt_tokens, completion_tokens, total_tokens, latency_ms)
+            (client_id, request_id, model, provider, prompt_tokens, completion_tokens, total_tokens,
+             cache_read_tokens, cache_write_tokens, latency_ms)
         SELECT * FROM UNNEST(
             $1::uuid[], $2::text[], $3::text[], $4::text[],
-            $5::int[], $6::int[], $7::int[], $8::int[]
+            $5::int[], $6::int[], $7::int[], $8::int[], $9::int[], $10::int[]
         )
         "#,
     )
@@ -140,6 +148,8 @@ async fn flush(pool: &sqlx::PgPool, buffer: &mut Vec<UsageEvent>) {
     .bind(&prompt_tokens)
     .bind(&completion_tokens)
     .bind(&total_tokens)
+    .bind(&cache_read_tokens)
+    .bind(&cache_write_tokens)
     .bind(&latency_ms)
     .execute(pool)
     .await;
@@ -168,6 +178,8 @@ mod tests {
             provider: "openai".to_string(),
             prompt_tokens: 100,
             completion_tokens: 50,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
             latency_ms: Some(200),
         });
         // Give the drainer a moment to consume.


### PR DESCRIPTION
Closes #126

## What

Surface the prompt-cache token counters made available by #125 across all three observability surfaces, so cache hit rate is **measurable** instead of inferred.

## Why

Prompt caching is the largest cost lever on Claude Code-style traffic, and there was no way to tell whether it was working. On production `ferrox:0.6.1`, `docker logs ferrox | grep -ci cache` → **0**. `ferrox_tokens_total` had exactly two `type` values, `usage_log` had no cache columns, and no log line mentioned caching. The only available signal was inferring a hit from a suspiciously small `input_tokens` — guesswork.

A caching regression (changed system prompt, lost cache breakpoint, failover to a non-caching provider) was silent and open-ended in cost.

## How

**Metrics** — two new `type` label values on the existing `ferrox_tokens_total` counter rather than a new metric, so PromQL over prompt/cache tokens stays one selector:

```promql
sum(rate(ferrox_tokens_total{type="cache_read"}[5m]))
/
sum(rate(ferrox_tokens_total{type=~"prompt|cache_read"}[5m]))
```

Each `inc_by` is guarded on `> 0`, so providers that don't cache never create the extra series — cardinality grows only where there is something to see.

**Logs** — `cache_read_tokens` / `cache_write_tokens` on both request-completed lines. Passed as `Option` via `(n > 0).then_some(n)`: `tracing` omits `Option` fields entirely when `None` (`tracing-core/src/field.rs:791`), so quiet paths stay byte-identical and no macro is duplicated.

**Database** — migration `20240004000000` adds two **nullable** `INT` columns, plumbed through *both* write paths and the list projection. Nullable with no backfill on purpose: `NULL` means "written by a gateway predating cache accounting", which is a different fact from a recorded `0` ("provider reported no cache usage").

**Shared reading** — `types::cache_tokens()` gives every surface the same reading, so metrics, logs and the DB cannot disagree, and the two equivalent cache-read representations from #125 are resolved in exactly one place.

## ⚠️ Deploy order

Once the gateway writes ten columns, an unmigrated control-plane database rejects **every** usage insert — not just the cache fields — so that window loses all usage rows.

**Deploy `ferrox-cp` before `ferrox`.** The control plane applies migrations at startup.

This is the deliberate answer to the acceptance criterion "still writes usage rows **or** fails loudly — decide and test one behaviour": it **fails loudly**. `insert_batch` returns `Err`, the gateway's flush logs `failed to flush usage records` with the database error and drops that batch. Covered by `insert_batch_fails_loudly_on_unmigrated_schema`, which drops the columns and asserts the error.

## Acceptance criteria

- [x] `{type="cache_read"}` / `{type="cache_write"}` increment with the same labels as `prompt`/`completion` — `non_zero_cache_tokens_increment_their_series`
- [x] Providers reporting no cache usage emit **no** new series — `zero_cache_tokens_create_no_series`, `cache_read_alone_does_not_create_a_write_series` (asserted against the encoded scrape text, so "absent" is distinguished from "present and zero")
- [x] Log lines include the fields when non-zero and omit them otherwise — `Option` semantics verified in `tracing-core`
- [x] `usage_log` persists both counters; migration applies over existing data, pre-existing rows keep working — `insert_batch_round_trips_cache_tokens` covers non-zero, recorded-zero and `NULL` in one batch
- [x] Unmigrated-database behaviour decided and tested — see Deploy order above
- [x] `docs/user/observability.md` documents both label values, both log fields, and a copy-pasteable cache-hit-rate query

## Testing

`cargo test --workspace -- --test-threads=1` — 303 + 107 passing (8 new), 0 failures. Plus `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --release --workspace`.

## Deferred

**#133** — the `token_usage` webhook payload (`TokenUsageEvent`) is now the only usage surface without cache counters. Adding fields there changes a wire contract external subscribers already consume, so it is tracked separately rather than widened into this PR.

## Out of scope

Budget and pricing changes. Cached tokens are billed at a discount (Anthropic ~10%, OpenAI 50%, Gemini 10%); weighting them in the budget enforcer is a deliberate follow-up. Grafana dashboard JSON is unchanged — only the documented query.
