### PR TITLE
fix(translation): preserve cache_control across the internal OpenAI representation

### DIFF
--- a/docs/user/providers.md
+++ b/docs/user/providers.md
@@ -173,6 +173,38 @@ Available models: `GLM-5.1`, `GLM-5`, `GLM-4.7`, `GLM-4.5-air`.
 
 ---
 
+## Prompt caching (`cache_control`)
+
+Anthropic-style `cache_control` breakpoints are preserved across **every**
+routing path, not just Anthropic-to-Anthropic:
+
+| Path | `cache_control` |
+|---|---|
+| `/anthropic/v1/messages` → `type: anthropic` | Forwarded verbatim (whole body passes through untouched) |
+| `/anthropic/v1/messages` → `type: openai` | Preserved |
+| `/v1/chat/completions` → `type: anthropic` | Preserved |
+| `/v1/chat/completions` → `type: openai` | Preserved |
+
+Breakpoints are carried on individual content blocks and on messages. A
+breakpoint on the **system** prompt is preserved too: the gateway's internal
+representation holds the system prompt as a single string, so the breakpoint
+travels alongside it and is re-attached as a system block when the request goes
+to an Anthropic-format provider.
+
+Requests that set no `cache_control` are forwarded byte-identically to before —
+no empty keys are introduced.
+
+> Anthropic-only content blocks that have no OpenAI equivalent (`thinking`,
+> `document`, `search_result`) are still dropped when routing to an
+> OpenAI-format provider, since the upstream would reject them. The dropped
+> block's type is logged at `debug` level.
+
+Cache effectiveness is measurable — see
+[Observability](observability.md#prompt-cache-metrics) for the
+`ferrox_tokens_total{type="cache_read"}` counter and a cache-hit-rate query.
+
+---
+
 ## Using multiple entries of the same provider
 
 Add multiple entries to multiply your rate limit budget or add geographic redundancy:

--- a/ferrox/src/anthropic_types.rs
+++ b/ferrox/src/anthropic_types.rs
@@ -53,6 +53,10 @@ pub struct AnthropicSystemBlock {
     #[serde(rename = "type")]
     pub block_type: String,
     pub text: Option<String>,
+    /// Prompt-cache breakpoint on the system prompt — typically the largest
+    /// cacheable span, so losing it is the most expensive drop of all.
+    #[serde(default)]
+    pub cache_control: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -73,11 +77,17 @@ pub enum AnthropicMessageContent {
 pub enum AnthropicContentBlock {
     Text {
         text: String,
+        /// Prompt-cache breakpoint. Preserved onto the internal representation
+        /// so it survives routing to a non-Anthropic provider.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<serde_json::Value>,
     },
     /// Image blocks are accepted but forwarded as-is (provider decides support).
     Image {
         #[allow(dead_code)]
         source: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<serde_json::Value>,
     },
     /// Assistant-turn tool invocation block.
     ToolUse {
@@ -95,8 +105,12 @@ pub enum AnthropicContentBlock {
         is_error: bool,
     },
     /// Catch-all for document, thinking, search_result, and future block types.
-    #[serde(other)]
-    Unknown,
+    ///
+    /// Captured verbatim rather than discarded so diagnostics can name the block
+    /// type. Must stay last: an untagged variant is tried only after every
+    /// tagged variant fails.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 // ── Tool definition in request ────────────────────────────────────────────────
@@ -196,12 +210,22 @@ pub struct AnthropicModelObject {
 // ── Translation: Anthropic request → internal ────────────────────────────────
 
 pub fn to_chat_completion_request(req: AnthropicMessagesRequest) -> ChatCompletionRequest {
+    // The internal representation carries the system prompt as a single string,
+    // so a per-block breakpoint has nowhere to live; hoist the last one seen to
+    // the request level. Last wins because Anthropic caches everything up to the
+    // final breakpoint, so the latest block is the widest span.
+    let mut system_cache_control: Option<serde_json::Value> = None;
     let system = req.system.map(|s| match s {
         AnthropicSystemContent::Text(t) => t,
         AnthropicSystemContent::Blocks(blocks) => blocks
             .into_iter()
             .filter(|b| b.block_type == "text")
-            .filter_map(|b| b.text)
+            .filter_map(|b| {
+                if b.cache_control.is_some() {
+                    system_cache_control = b.cache_control;
+                }
+                b.text
+            })
             .collect::<Vec<_>>()
             // Separate system blocks are distinct lines; joining with "" would
             // glue e.g. "You are" + "helpful" into "You arehelpful".
@@ -261,6 +285,9 @@ pub fn to_chat_completion_request(req: AnthropicMessagesRequest) -> ChatCompleti
     if let Some(top_k) = req.top_k {
         extra.insert("top_k".to_string(), serde_json::Value::from(top_k));
     }
+    if let Some(cc) = system_cache_control {
+        extra.insert(crate::types::ANTHROPIC_SYSTEM_CACHE_CONTROL.to_string(), cc);
+    }
 
     ChatCompletionRequest {
         model: req.model,
@@ -296,6 +323,7 @@ fn anthropic_messages_to_internal(messages: Vec<AnthropicMessage>) -> Vec<ChatMe
                     tool_calls: None,
                     tool_call_id: None,
                     reasoning_content: None,
+                    extra: Default::default(),
                 });
             }
             AnthropicMessageContent::Blocks(blocks) => {
@@ -304,6 +332,21 @@ fn anthropic_messages_to_internal(messages: Vec<AnthropicMessage>) -> Vec<ChatMe
         }
     }
     result
+}
+
+/// Wrap a block's `cache_control` as the `extra` map of an internal content part.
+///
+/// Returns an empty map when there is no breakpoint, which keeps the serialized
+/// part byte-identical to one from before cache_control was preserved (and does
+/// not allocate).
+fn cache_control_extra(
+    cache_control: Option<serde_json::Value>,
+) -> HashMap<String, serde_json::Value> {
+    let mut extra = HashMap::new();
+    if let Some(cc) = cache_control {
+        extra.insert(crate::types::CACHE_CONTROL.to_string(), cc);
+    }
+    extra
 }
 
 /// Expand one Anthropic message (block content) into ≥1 internal messages.
@@ -319,14 +362,24 @@ fn convert_blocks(role: String, blocks: Vec<AnthropicContentBlock>, out: &mut Ve
 
     for block in blocks {
         match block {
-            AnthropicContentBlock::Text { text } => {
-                content_parts.push(ContentPart::Text { text });
+            AnthropicContentBlock::Text {
+                text,
+                cache_control,
+            } => {
+                content_parts.push(ContentPart::Text {
+                    text,
+                    extra: cache_control_extra(cache_control),
+                });
             }
-            AnthropicContentBlock::Image { source } => {
+            AnthropicContentBlock::Image {
+                source,
+                cache_control,
+            } => {
                 // Translate to an OpenAI image_url part instead of dropping it.
                 if let Some(url) = anthropic_image_source_to_url(&source) {
                     content_parts.push(ContentPart::ImageUrl {
                         image_url: crate::types::ImageUrl { url, detail: None },
+                        extra: cache_control_extra(cache_control),
                     });
                 }
             }
@@ -360,10 +413,16 @@ fn convert_blocks(role: String, blocks: Vec<AnthropicContentBlock>, out: &mut Ve
                 }
                 tool_results.push((tool_use_id, text));
             }
-            // Document/thinking/unknown blocks have no OpenAI equivalent. Warn so
-            // a silently-dropped block isn't mistaken for successful handling.
-            AnthropicContentBlock::Unknown => {
-                tracing::warn!(
+            // Document/thinking/unknown blocks have no OpenAI equivalent, so
+            // they cannot be forwarded to an OpenAI-format provider without the
+            // upstream rejecting the request. Name the type so the drop is
+            // diagnosable instead of anonymous.
+            AnthropicContentBlock::Unknown(value) => {
+                tracing::debug!(
+                    block_type = value
+                        .get("type")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("<untyped>"),
                     "dropping unsupported Anthropic content block (no OpenAI equivalent)"
                 );
             }
@@ -383,6 +442,7 @@ fn convert_blocks(role: String, blocks: Vec<AnthropicContentBlock>, out: &mut Ve
             },
             tool_call_id: None,
             reasoning_content: None,
+            extra: Default::default(),
         });
     } else {
         // User turn: emit the `tool` result messages FIRST, then any user
@@ -406,6 +466,7 @@ fn convert_blocks(role: String, blocks: Vec<AnthropicContentBlock>, out: &mut Ve
                 tool_calls: None,
                 tool_call_id: Some(tool_use_id),
                 reasoning_content: None,
+                extra: Default::default(),
             });
         }
         // Re-home any tool_result images onto the trailing user message so they
@@ -420,6 +481,7 @@ fn convert_blocks(role: String, blocks: Vec<AnthropicContentBlock>, out: &mut Ve
                 tool_calls: None,
                 tool_call_id: None,
                 reasoning_content: None,
+                extra: Default::default(),
             });
         }
     }
@@ -432,11 +494,17 @@ fn parts_to_content(parts: Vec<ContentPart>) -> Option<MessageContent> {
     if parts.is_empty() {
         return None;
     }
-    if parts.iter().all(|p| matches!(p, ContentPart::Text { .. })) {
+    // Collapsing several text parts into one string is a convenience for the
+    // common case, but it destroys per-part attributes. Only do it when no part
+    // carries any — otherwise a `cache_control` breakpoint would be joined away.
+    let all_plain_text = parts
+        .iter()
+        .all(|p| matches!(p, ContentPart::Text { extra, .. } if extra.is_empty()));
+    if all_plain_text {
         let text = parts
             .into_iter()
             .filter_map(|p| match p {
-                ContentPart::Text { text } => Some(text),
+                ContentPart::Text { text, .. } => Some(text),
                 _ => None,
             })
             .collect::<Vec<_>>()
@@ -520,6 +588,7 @@ fn tool_result_images(v: Option<&serde_json::Value>) -> Vec<ContentPart> {
                     .and_then(anthropic_image_source_to_url)
                     .map(|url| ContentPart::ImageUrl {
                         image_url: crate::types::ImageUrl { url, detail: None },
+                        extra: Default::default(),
                     }),
                 _ => None,
             })
@@ -552,7 +621,7 @@ pub fn to_anthropic_response(resp: ChatCompletionResponse) -> AnthropicMessagesR
                 MessageContent::Parts(parts) => parts
                     .iter()
                     .filter_map(|p| match p {
-                        ContentPart::Text { text } => Some(text.as_str()),
+                        ContentPart::Text { text, .. } => Some(text.as_str()),
                         _ => None,
                     })
                     .collect::<Vec<_>>()
@@ -1135,6 +1204,7 @@ mod tests {
         req.system = Some(AnthropicSystemContent::Blocks(vec![AnthropicSystemBlock {
             block_type: "text".to_string(),
             text: Some("Act as a robot.".to_string()),
+            cache_control: None,
         }]));
         let out = to_chat_completion_request(req);
         assert_eq!(out.system.as_deref(), Some("Act as a robot."));
@@ -1146,6 +1216,7 @@ mod tests {
         req.system = Some(AnthropicSystemContent::Blocks(vec![AnthropicSystemBlock {
             block_type: "unknown".to_string(),
             text: Some("ignored".to_string()),
+            cache_control: None,
         }]));
         let out = to_chat_completion_request(req);
         assert_eq!(out.system.as_deref(), Some(""));
@@ -1167,6 +1238,7 @@ mod tests {
                 role: "user".to_string(),
                 content: AnthropicMessageContent::Blocks(vec![AnthropicContentBlock::Text {
                     text: "Hi there".to_string(),
+                    cache_control: None,
                 }]),
             }],
             ..minimal_request("claude-sonnet")
@@ -1270,6 +1342,7 @@ mod tests {
                 content: AnthropicMessageContent::Blocks(vec![
                     AnthropicContentBlock::Text {
                         text: "Let me search.".to_string(),
+                        cache_control: None,
                     },
                     AnthropicContentBlock::ToolUse {
                         id: "toolu_abc".to_string(),
@@ -1322,6 +1395,7 @@ mod tests {
                 content: AnthropicMessageContent::Blocks(vec![
                     AnthropicContentBlock::Text {
                         text: "Here is the result:".to_string(),
+                        cache_control: None,
                     },
                     AnthropicContentBlock::ToolResult {
                         tool_use_id: "toolu_x".to_string(),
@@ -1371,6 +1445,7 @@ mod tests {
                         },
                         AnthropicContentBlock::Text {
                             text: "Base directory for this skill: /home/x".to_string(),
+                            cache_control: None,
                         },
                     ]),
                 },
@@ -1434,7 +1509,128 @@ mod tests {
         let block_json =
             r#"{"type": "document", "source": {"type": "url", "url": "https://example.com"}}"#;
         let block: AnthropicContentBlock = serde_json::from_str(block_json).unwrap();
-        assert!(matches!(block, AnthropicContentBlock::Unknown));
+        assert!(matches!(block, AnthropicContentBlock::Unknown(_)));
+    }
+
+    // ── Prompt-cache breakpoint preservation (#127) ──────────────────────────
+
+    #[test]
+    fn cache_control_on_message_block_survives_translation() {
+        let json = r#"{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[
+            {"type":"text","text":"cached prefix","cache_control":{"type":"ephemeral"}},
+            {"type":"text","text":"uncached suffix"}
+        ]}]}"#;
+        let req: AnthropicMessagesRequest = serde_json::from_str(json).unwrap();
+        let internal = to_chat_completion_request(req);
+
+        let parts = match internal.messages[0].content.as_ref().unwrap() {
+            MessageContent::Parts(p) => p,
+            other => panic!("expected parts, got {other:?}"),
+        };
+        match &parts[0] {
+            ContentPart::Text { text, extra } => {
+                assert_eq!(text, "cached prefix");
+                assert_eq!(
+                    extra["cache_control"],
+                    serde_json::json!({"type":"ephemeral"})
+                );
+            }
+            other => panic!("expected text part, got {other:?}"),
+        }
+        match &parts[1] {
+            ContentPart::Text { extra, .. } => {
+                assert!(extra.is_empty(), "unmarked block must carry no extras");
+            }
+            other => panic!("expected text part, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cache_control_on_system_block_is_hoisted_to_request_extra() {
+        // The internal `system` is a flat string, so a per-block breakpoint has
+        // to travel at request level or it is lost.
+        let json = r#"{"model":"m","max_tokens":10,
+            "system":[{"type":"text","text":"You are helpful.","cache_control":{"type":"ephemeral"}}],
+            "messages":[{"role":"user","content":"hi"}]}"#;
+        let req: AnthropicMessagesRequest = serde_json::from_str(json).unwrap();
+        let internal = to_chat_completion_request(req);
+
+        assert_eq!(internal.system.as_deref(), Some("You are helpful."));
+        assert_eq!(
+            internal.extra[crate::types::ANTHROPIC_SYSTEM_CACHE_CONTROL],
+            serde_json::json!({"type":"ephemeral"})
+        );
+    }
+
+    #[test]
+    fn system_without_cache_control_adds_no_request_extra() {
+        let json = r#"{"model":"m","max_tokens":10,
+            "system":[{"type":"text","text":"You are helpful."}],
+            "messages":[{"role":"user","content":"hi"}]}"#;
+        let req: AnthropicMessagesRequest = serde_json::from_str(json).unwrap();
+        let internal = to_chat_completion_request(req);
+        assert!(!internal
+            .extra
+            .contains_key(crate::types::ANTHROPIC_SYSTEM_CACHE_CONTROL));
+    }
+
+    #[test]
+    fn content_part_without_extras_serializes_byte_identically() {
+        // Guards the "no behaviour change for requests without extras" criterion.
+        let part = ContentPart::Text {
+            text: "hi".to_string(),
+            extra: Default::default(),
+        };
+        assert_eq!(
+            serde_json::to_string(&part).unwrap(),
+            r#"{"type":"text","text":"hi"}"#
+        );
+    }
+
+    #[test]
+    fn content_part_round_trips_cache_control_through_json() {
+        let json = r#"{"type":"text","text":"hi","cache_control":{"type":"ephemeral"}}"#;
+        let part: ContentPart = serde_json::from_str(json).unwrap();
+        match &part {
+            ContentPart::Text { extra, .. } => {
+                assert_eq!(
+                    extra["cache_control"],
+                    serde_json::json!({"type":"ephemeral"})
+                );
+                // The internally-tagged discriminant must not leak into `extra`.
+                assert!(
+                    !extra.contains_key("type"),
+                    "tag leaked into extra: {extra:?}"
+                );
+            }
+            other => panic!("expected text part, got {other:?}"),
+        }
+        assert_eq!(
+            serde_json::to_value(&part).unwrap(),
+            serde_json::from_str::<serde_json::Value>(json).unwrap()
+        );
+    }
+
+    #[test]
+    fn unknown_block_is_still_dropped_but_typed() {
+        // Anthropic-only blocks cannot be forwarded to an OpenAI-format
+        // provider, but the type is now captured for diagnostics.
+        let block: AnthropicContentBlock =
+            serde_json::from_str(r#"{"type":"thinking","thinking":"hmm"}"#).unwrap();
+        match block {
+            AnthropicContentBlock::Unknown(v) => {
+                assert_eq!(v.get("type").and_then(|t| t.as_str()), Some("thinking"));
+            }
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn well_formed_text_block_still_wins_over_untagged_fallback() {
+        // The untagged catch-all must not shadow the tagged variants.
+        let block: AnthropicContentBlock =
+            serde_json::from_str(r#"{"type":"text","text":"hello"}"#).unwrap();
+        assert!(matches!(block, AnthropicContentBlock::Text { .. }));
     }
 
     #[test]
@@ -1451,7 +1647,7 @@ mod tests {
                 assert!(
                     parts
                         .iter()
-                        .any(|p| matches!(p, ContentPart::ImageUrl { image_url }
+                        .any(|p| matches!(p, ContentPart::ImageUrl { image_url, .. }
                         if image_url.url == "data:image/png;base64,AAAA")),
                     "image preserved as a data URL"
                 );
@@ -1531,7 +1727,7 @@ mod tests {
                 let imgs: Vec<&crate::types::ImageUrl> = parts
                     .iter()
                     .filter_map(|p| match p {
-                        ContentPart::ImageUrl { image_url } => Some(image_url),
+                        ContentPart::ImageUrl { image_url, .. } => Some(image_url),
                         _ => None,
                     })
                     .collect();
@@ -1566,7 +1762,7 @@ mod tests {
                 assert_eq!(parts.len(), 1);
                 assert!(matches!(
                     &parts[0],
-                    ContentPart::ImageUrl { image_url } if image_url.url == "https://example.com/a.png"
+                    ContentPart::ImageUrl { image_url, .. } if image_url.url == "https://example.com/a.png"
                 ));
             }
             other => panic!("expected image parts, got {other:?}"),
@@ -1625,6 +1821,7 @@ mod tests {
                 content: AnthropicMessageContent::Blocks(vec![
                     AnthropicContentBlock::Text {
                         text: "hi".to_string(),
+                        cache_control: None,
                     },
                     AnthropicContentBlock::ToolResult {
                         tool_use_id: "t1".to_string(),
@@ -1681,6 +1878,7 @@ mod tests {
                     tool_calls: None,
                     tool_call_id: None,
                     reasoning_content: None,
+                    extra: Default::default(),
                 },
                 finish_reason: Some(finish_reason.to_string()),
                 extra: Default::default(),
@@ -1764,6 +1962,7 @@ mod tests {
                     }]),
                     tool_call_id: None,
                     reasoning_content: None,
+                    extra: Default::default(),
                 },
                 finish_reason: Some("tool_calls".to_string()),
                 extra: Default::default(),
@@ -1831,7 +2030,7 @@ mod tests {
         let urls: Vec<&str> = imgs
             .iter()
             .filter_map(|p| match p {
-                ContentPart::ImageUrl { image_url } => Some(image_url.url.as_str()),
+                ContentPart::ImageUrl { image_url, .. } => Some(image_url.url.as_str()),
                 _ => None,
             })
             .collect();

--- a/ferrox/src/providers/anthropic.rs
+++ b/ferrox/src/providers/anthropic.rs
@@ -154,8 +154,11 @@ impl ProviderAdapter for AnthropicAdapter {
 struct AnthropicRequest {
     model: String,
     messages: Vec<AnthropicMessage>,
+    /// Plain string when there is no system breakpoint, or a one-element block
+    /// array carrying `cache_control` when there is — Anthropic accepts both,
+    /// and only the block form can hold a breakpoint.
     #[serde(skip_serializing_if = "Option::is_none")]
-    system: Option<String>,
+    system: Option<Value>,
     max_tokens: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     stream: Option<bool>,
@@ -198,9 +201,15 @@ enum AnthropicContent {
 enum AnthropicPart {
     Text {
         text: String,
+        /// Prompt-cache breakpoint recovered from the internal content part, so
+        /// a breakpoint set by an OpenAI-format client still reaches Anthropic.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<Value>,
     },
     Image {
         source: AnthropicImageSource,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<Value>,
     },
     ToolUse {
         id: String,
@@ -300,7 +309,17 @@ fn build_request_body(
     stream: bool,
     extras: &AnthropicExtras,
 ) -> AnthropicRequest {
-    let system = req.system_message();
+    // A system breakpoint hoisted by the Anthropic→internal translation (the
+    // internal `system` is a plain string and cannot carry one) is restored here
+    // by emitting the system prompt in block form.
+    let system = req.system_message().map(|text| {
+        match req.extra.get(crate::types::ANTHROPIC_SYSTEM_CACHE_CONTROL) {
+            Some(cc) => {
+                serde_json::json!([{"type": "text", "text": text, "cache_control": cc}])
+            }
+            None => Value::String(text),
+        }
+    });
 
     // Filter out system messages; Anthropic does not allow them in the messages array
     let messages: Vec<AnthropicMessage> = req
@@ -374,6 +393,11 @@ fn openai_tool_choice_to_anthropic(tc: &Value) -> Value {
     }
 }
 
+/// Pull a `cache_control` breakpoint out of an internal `extra` map, if present.
+fn cache_control_of(extra: &std::collections::HashMap<String, Value>) -> Option<Value> {
+    extra.get(crate::types::CACHE_CONTROL).cloned()
+}
+
 fn convert_message(msg: &ChatMessage) -> AnthropicMessage {
     let role = match msg.role.as_str() {
         "assistant" => "assistant",
@@ -392,7 +416,7 @@ fn convert_message(msg: &ChatMessage) -> AnthropicMessage {
                 MessageContent::Parts(ps) => ps
                     .iter()
                     .filter_map(|p| {
-                        if let ContentPart::Text { text } = p {
+                        if let ContentPart::Text { text, .. } = p {
                             Some(text.as_str())
                         } else {
                             None
@@ -402,7 +426,10 @@ fn convert_message(msg: &ChatMessage) -> AnthropicMessage {
                     .join(""),
             };
             if !text.is_empty() {
-                parts.push(AnthropicPart::Text { text });
+                parts.push(AnthropicPart::Text {
+                    text,
+                    cache_control: None,
+                });
             }
         }
 
@@ -425,7 +452,7 @@ fn convert_message(msg: &ChatMessage) -> AnthropicMessage {
                 MessageContent::Parts(parts) => parts
                     .iter()
                     .filter_map(|p| {
-                        if let ContentPart::Text { text } = p {
+                        if let ContentPart::Text { text, .. } = p {
                             Some(text.as_str())
                         } else {
                             None
@@ -447,9 +474,13 @@ fn convert_message(msg: &ChatMessage) -> AnthropicMessage {
                 let converted: Vec<AnthropicPart> = parts
                     .iter()
                     .map(|p| match p {
-                        ContentPart::Text { text } => AnthropicPart::Text { text: text.clone() },
-                        ContentPart::ImageUrl { image_url } => AnthropicPart::Image {
+                        ContentPart::Text { text, extra } => AnthropicPart::Text {
+                            text: text.clone(),
+                            cache_control: cache_control_of(extra),
+                        },
+                        ContentPart::ImageUrl { image_url, extra } => AnthropicPart::Image {
                             source: image_url_to_source(&image_url.url),
+                            cache_control: cache_control_of(extra),
                         },
                     })
                     .collect();
@@ -557,6 +588,7 @@ fn anthropic_to_openai_response(resp: AnthropicResponse, model_id: &str) -> Chat
         } else {
             Some(reasoning)
         },
+        extra: Default::default(),
     };
 
     let finish_reason = resp.stop_reason.map(|r| match r.as_str() {
@@ -639,6 +671,140 @@ fn transform_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Prompt-cache breakpoints, OpenAI-internal → Anthropic (#127) ─────────
+
+    fn req_with(messages: Vec<ChatMessage>) -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: "m".to_string(),
+            messages,
+            stream: None,
+            temperature: None,
+            max_tokens: Some(10),
+            top_p: None,
+            stop: None,
+            tools: None,
+            tool_choice: None,
+            system: None,
+            extra_headers: Default::default(),
+            raw_anthropic_body: None,
+            extra: Default::default(),
+        }
+    }
+
+    fn user_msg_with_parts(parts: Vec<crate::types::ContentPart>) -> ChatMessage {
+        ChatMessage {
+            role: "user".to_string(),
+            content: Some(crate::types::MessageContent::Parts(parts)),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            extra: Default::default(),
+        }
+    }
+
+    #[test]
+    fn cache_control_reaches_the_anthropic_body() {
+        let ephemeral = serde_json::json!({"type": "ephemeral"});
+        let req = req_with(vec![user_msg_with_parts(vec![
+            crate::types::ContentPart::Text {
+                text: "cached".to_string(),
+                extra: std::collections::HashMap::from([(
+                    "cache_control".to_string(),
+                    ephemeral.clone(),
+                )]),
+            },
+            crate::types::ContentPart::Text {
+                text: "fresh".to_string(),
+                extra: Default::default(),
+            },
+        ])]);
+
+        let body = serde_json::to_value(build_request_body(
+            &req,
+            "claude-sonnet",
+            false,
+            &AnthropicExtras { thinking: None },
+        ))
+        .unwrap();
+
+        let parts = &body["messages"][0]["content"];
+        assert_eq!(parts[0]["cache_control"], ephemeral);
+        assert_eq!(parts[0]["text"], "cached");
+        assert!(
+            parts[1].get("cache_control").is_none(),
+            "unmarked part must stay unmarked: {parts:?}"
+        );
+    }
+
+    #[test]
+    fn system_cache_control_is_restored_as_a_block() {
+        let ephemeral = serde_json::json!({"type": "ephemeral"});
+        let mut req = req_with(vec![]);
+        req.system = Some("You are helpful.".to_string());
+        req.extra.insert(
+            crate::types::ANTHROPIC_SYSTEM_CACHE_CONTROL.to_string(),
+            ephemeral.clone(),
+        );
+
+        let body = serde_json::to_value(build_request_body(
+            &req,
+            "claude-sonnet",
+            false,
+            &AnthropicExtras { thinking: None },
+        ))
+        .unwrap();
+
+        assert_eq!(
+            body["system"],
+            serde_json::json!([{
+                "type": "text",
+                "text": "You are helpful.",
+                "cache_control": {"type": "ephemeral"}
+            }])
+        );
+    }
+
+    #[test]
+    fn system_without_breakpoint_stays_a_plain_string() {
+        // Byte-compatible with the pre-#127 wire format.
+        let mut req = req_with(vec![]);
+        req.system = Some("You are helpful.".to_string());
+
+        let body = serde_json::to_value(build_request_body(
+            &req,
+            "claude-sonnet",
+            false,
+            &AnthropicExtras { thinking: None },
+        ))
+        .unwrap();
+
+        assert_eq!(body["system"], serde_json::json!("You are helpful."));
+    }
+
+    #[test]
+    fn parts_without_extras_serialize_without_cache_control() {
+        let req = req_with(vec![user_msg_with_parts(vec![
+            crate::types::ContentPart::Text {
+                text: "plain".to_string(),
+                extra: Default::default(),
+            },
+        ])]);
+
+        let body = serde_json::to_value(build_request_body(
+            &req,
+            "claude-sonnet",
+            false,
+            &AnthropicExtras { thinking: None },
+        ))
+        .unwrap();
+
+        assert_eq!(
+            body["messages"][0]["content"][0],
+            serde_json::json!({"type": "text", "text": "plain"})
+        );
+    }
 
     #[test]
     fn thinking_block_deserializes_and_maps_to_reasoning() {

--- a/ferrox/src/providers/bedrock.rs
+++ b/ferrox/src/providers/bedrock.rs
@@ -399,11 +399,11 @@ fn user_content_blocks(content: &Option<MessageContent>) -> Vec<ContentBlock> {
         Some(MessageContent::Parts(parts)) => parts
             .iter()
             .filter_map(|p| match p {
-                ContentPart::Text { text } if !text.is_empty() => {
+                ContentPart::Text { text, .. } if !text.is_empty() => {
                     Some(ContentBlock::Text(text.clone()))
                 }
                 ContentPart::Text { .. } => None,
-                ContentPart::ImageUrl { image_url } => image_block(&image_url.url),
+                ContentPart::ImageUrl { image_url, .. } => image_block(&image_url.url),
             })
             .collect(),
         None => Vec::new(),
@@ -598,6 +598,7 @@ fn converse_output_to_openai(
         },
         tool_call_id: None,
         reasoning_content: None,
+        extra: Default::default(),
     };
 
     ChatCompletionResponse {
@@ -712,7 +713,7 @@ fn text_of(content: &Option<MessageContent>) -> String {
         Some(MessageContent::Parts(parts)) => parts
             .iter()
             .filter_map(|p| match p {
-                ContentPart::Text { text } => Some(text.as_str()),
+                ContentPart::Text { text, .. } => Some(text.as_str()),
                 _ => None,
             })
             .collect::<Vec<_>>()
@@ -765,6 +766,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: None,
             reasoning_content: None,
+            extra: Default::default(),
         }
     }
 
@@ -783,6 +785,7 @@ mod tests {
             }]),
             tool_call_id: None,
             reasoning_content: None,
+            extra: Default::default(),
         }
     }
 
@@ -810,6 +813,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: Some("t1".into()),
             reasoning_content: None,
+            extra: Default::default(),
         };
         let out = build_messages(&req(vec![asst_tool_call(), tool_msg], false, None)).unwrap();
         assert_eq!(out.len(), 2);
@@ -917,18 +921,21 @@ mod tests {
             content: Some(MessageContent::Parts(vec![
                 ContentPart::Text {
                     text: "look".into(),
+                    extra: Default::default(),
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
                         url: "data:image/png;base64,QUJD".into(),
                         detail: None,
                     },
+                    extra: Default::default(),
                 },
             ])),
             name: None,
             tool_calls: None,
             tool_call_id: None,
             reasoning_content: None,
+            extra: Default::default(),
         };
         let blocks = user_content_blocks(&m.content);
         assert_eq!(blocks.len(), 2);
@@ -949,6 +956,7 @@ mod tests {
                     url: "https://example.com/cat.png".into(),
                     detail: None,
                 },
+                extra: Default::default(),
             }])));
         assert!(
             blocks.is_empty(),

--- a/ferrox/src/providers/gemini.rs
+++ b/ferrox/src/providers/gemini.rs
@@ -63,7 +63,7 @@ impl GeminiAdapter {
         for msg in &mut resolved.messages {
             if let Some(MessageContent::Parts(parts)) = &mut msg.content {
                 for part in parts.iter_mut() {
-                    if let ContentPart::ImageUrl { image_url } = part {
+                    if let ContentPart::ImageUrl { image_url, .. } = part {
                         if !image_url.url.starts_with("data:") {
                             if let Some(data_url) =
                                 self.fetch_image_as_data_url(&image_url.url).await
@@ -581,8 +581,8 @@ fn convert_message(msg: &ChatMessage, tool_names: &HashMap<String, String>) -> G
         Some(MessageContent::Parts(cparts)) => {
             for p in cparts {
                 match p {
-                    ContentPart::Text { text } => parts.push(text_part(text.clone())),
-                    ContentPart::ImageUrl { image_url } => {
+                    ContentPart::Text { text, .. } => parts.push(text_part(text.clone())),
+                    ContentPart::ImageUrl { image_url, .. } => {
                         if let Some((mime_type, data)) = parse_data_url(&image_url.url) {
                             parts.push(GeminiPart {
                                 text: None,
@@ -740,6 +740,7 @@ fn gemini_to_openai_response(resp: GeminiResponse, model_id: &str) -> ChatComple
                 },
                 tool_call_id: None,
                 reasoning_content: None,
+                extra: Default::default(),
             };
 
             Choice {
@@ -826,15 +827,17 @@ mod tests {
                     url: "data:image/png;base64,QUJD".into(),
                     detail: None,
                 },
+                extra: Default::default(),
             }])),
             name: None,
             tool_calls: None,
             tool_call_id: None,
             reasoning_content: None,
+            extra: Default::default(),
         };
         let resolved = a.inline_remote_images(&req(vec![msg], None)).await;
         if let Some(MessageContent::Parts(parts)) = &resolved.messages[0].content {
-            if let ContentPart::ImageUrl { image_url } = &parts[0] {
+            if let ContentPart::ImageUrl { image_url, .. } = &parts[0] {
                 assert_eq!(image_url.url, "data:image/png;base64,QUJD");
             } else {
                 panic!("expected image part");
@@ -884,6 +887,7 @@ mod tests {
             }]),
             tool_call_id: None,
             reasoning_content: None,
+            extra: Default::default(),
         }
     }
 
@@ -895,6 +899,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: Some("t1".into()),
             reasoning_content: None,
+            extra: Default::default(),
         }
     }
 

--- a/ferrox/src/providers/openai.rs
+++ b/ferrox/src/providers/openai.rs
@@ -261,6 +261,7 @@ fn build_request_body(req: &ChatCompletionRequest, model_id: &str, stream: bool)
                     tool_calls: None,
                     tool_call_id: None,
                     reasoning_content: None,
+                    extra: Default::default(),
                 },
             );
         }
@@ -315,6 +316,94 @@ fn build_request_body(req: &ChatCompletionRequest, model_id: &str, stream: bool)
 mod tests {
     use super::*;
     use crate::config::{DefaultsConfig, ProviderConfig, ProviderType};
+
+    /// The path from the original report: `/anthropic/v1/messages` routed to a
+    /// `type: openai` provider. The breakpoint must reach the outbound body.
+    #[test]
+    fn cache_control_survives_into_the_openai_body() {
+        let ephemeral = serde_json::json!({"type": "ephemeral"});
+        let req = ChatCompletionRequest {
+            model: "m".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: Some(MessageContent::Parts(vec![
+                    crate::types::ContentPart::Text {
+                        text: "cached".to_string(),
+                        extra: std::collections::HashMap::from([(
+                            "cache_control".to_string(),
+                            ephemeral.clone(),
+                        )]),
+                    },
+                ])),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+                reasoning_content: None,
+                extra: std::collections::HashMap::from([(
+                    "cache_control".to_string(),
+                    ephemeral.clone(),
+                )]),
+            }],
+            stream: None,
+            temperature: None,
+            max_tokens: Some(10),
+            top_p: None,
+            stop: None,
+            tools: None,
+            tool_choice: None,
+            system: None,
+            extra_headers: Default::default(),
+            raw_anthropic_body: None,
+            extra: Default::default(),
+        };
+
+        let body = serde_json::to_value(build_request_body(&req, "kimi-k2", false)).unwrap();
+        let msg = &body["messages"][0];
+        assert_eq!(msg["cache_control"], ephemeral, "message-level breakpoint");
+        assert_eq!(
+            msg["content"][0]["cache_control"], ephemeral,
+            "block-level breakpoint"
+        );
+    }
+
+    #[test]
+    fn message_without_extras_serializes_without_new_keys() {
+        let req = ChatCompletionRequest {
+            model: "m".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: Some(MessageContent::Text("hi".to_string())),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+                reasoning_content: None,
+                extra: Default::default(),
+            }],
+            stream: None,
+            temperature: None,
+            max_tokens: Some(10),
+            top_p: None,
+            stop: None,
+            tools: None,
+            tool_choice: None,
+            system: None,
+            extra_headers: Default::default(),
+            raw_anthropic_body: None,
+            extra: Default::default(),
+        };
+
+        let body = serde_json::to_value(build_request_body(&req, "kimi-k2", false)).unwrap();
+        assert_eq!(
+            body["messages"][0],
+            serde_json::json!({
+                "role": "user",
+                "content": "hi",
+                "name": null,
+                "tool_calls": null,
+                "tool_call_id": null
+            })
+        );
+    }
 
     fn defaults() -> DefaultsConfig {
         DefaultsConfig::default()

--- a/ferrox/src/providers/openai.rs
+++ b/ferrox/src/providers/openai.rs
@@ -367,6 +367,39 @@ mod tests {
     }
 
     #[test]
+    fn system_cache_control_key_does_not_leak_to_openai_upstreams() {
+        // The hoisted system breakpoint is gateway-private; the `_` prefix is
+        // what keeps it out of the outbound body. Pin that explicitly, since a
+        // rename without the prefix would silently start leaking it.
+        let mut req = ChatCompletionRequest {
+            model: "m".to_string(),
+            messages: vec![],
+            stream: None,
+            temperature: None,
+            max_tokens: Some(10),
+            top_p: None,
+            stop: None,
+            tools: None,
+            tool_choice: None,
+            system: None,
+            extra_headers: Default::default(),
+            raw_anthropic_body: None,
+            extra: Default::default(),
+        };
+        req.extra.insert(
+            crate::types::ANTHROPIC_SYSTEM_CACHE_CONTROL.to_string(),
+            serde_json::json!({"type": "ephemeral"}),
+        );
+
+        let body = serde_json::to_value(build_request_body(&req, "kimi-k2", false)).unwrap();
+        assert!(
+            body.get(crate::types::ANTHROPIC_SYSTEM_CACHE_CONTROL)
+                .is_none(),
+            "gateway-private key leaked upstream: {body}"
+        );
+    }
+
+    #[test]
     fn message_without_extras_serializes_without_new_keys() {
         let req = ChatCompletionRequest {
             model: "m".to_string(),

--- a/ferrox/src/types.rs
+++ b/ferrox/src/types.rs
@@ -53,7 +53,7 @@ impl ChatCompletionRequest {
                     MessageContent::Parts(parts) => parts
                         .iter()
                         .filter_map(|p| match p {
-                            ContentPart::Text { text } => Some(text.as_str()),
+                            ContentPart::Text { text, .. } => Some(text.as_str()),
                             _ => None,
                         })
                         .collect::<Vec<_>>()
@@ -75,6 +75,16 @@ pub struct ChatMessage {
     /// `content`; preserved so it round-trips instead of being dropped.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
+    /// Pass-through for message-level attributes with no field of their own —
+    /// `cache_control` above all — so they survive the internal representation
+    /// instead of being erased in translation. Mirrors the catch-all on
+    /// [`ChatCompletionRequest`] and [`Usage`].
+    #[serde(
+        flatten,
+        default,
+        skip_serializing_if = "std::collections::HashMap::is_empty"
+    )]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -87,9 +97,40 @@ pub enum MessageContent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentPart {
-    Text { text: String },
-    ImageUrl { image_url: ImageUrl },
+    Text {
+        text: String,
+        /// Per-block pass-through, carrying `cache_control` breakpoints across
+        /// the internal representation. See [`ChatMessage::extra`].
+        #[serde(
+            flatten,
+            default,
+            skip_serializing_if = "std::collections::HashMap::is_empty"
+        )]
+        extra: std::collections::HashMap<String, serde_json::Value>,
+    },
+    ImageUrl {
+        image_url: ImageUrl,
+        #[serde(
+            flatten,
+            default,
+            skip_serializing_if = "std::collections::HashMap::is_empty"
+        )]
+        extra: std::collections::HashMap<String, serde_json::Value>,
+    },
 }
+
+/// Key under which Anthropic prompt-cache breakpoints travel, on both
+/// [`ChatMessage::extra`] and [`ContentPart::Text::extra`].
+pub const CACHE_CONTROL: &str = "cache_control";
+
+/// Request-level [`ChatCompletionRequest::extra`] key holding the `cache_control`
+/// of the **system** prompt.
+///
+/// The internal representation flattens Anthropic system blocks into a single
+/// string, which has nowhere to hold a per-block breakpoint, so it is hoisted
+/// here — the same private-key convention already used by `_anthropic_thinking`
+/// and `_anthropic_betas`.
+pub const ANTHROPIC_SYSTEM_CACHE_CONTROL: &str = "_anthropic_system_cache_control";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImageUrl {
@@ -432,6 +473,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: None,
             reasoning_content: None,
+            extra: Default::default(),
         }
     }
 
@@ -471,15 +513,18 @@ mod tests {
             content: Some(MessageContent::Parts(vec![
                 ContentPart::Text {
                     text: "Part1 ".to_string(),
+                    extra: Default::default(),
                 },
                 ContentPart::Text {
                     text: "Part2".to_string(),
+                    extra: Default::default(),
                 },
             ])),
             name: None,
             tool_calls: None,
             tool_call_id: None,
             reasoning_content: None,
+            extra: Default::default(),
         });
         assert_eq!(r.system_message(), Some("Part1 Part2".to_string()));
     }
@@ -494,6 +539,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: None,
             reasoning_content: None,
+            extra: Default::default(),
         });
         assert_eq!(r.system_message(), None);
     }


### PR DESCRIPTION
Closes #127

## What

Give `ChatMessage` and `ContentPart` the `#[serde(flatten)] extra` catch-all that `ChatCompletionRequest` and `Usage` already have, so `cache_control` breakpoints survive the internal OpenAI representation instead of being erased.

## Why

Prompt-cache breakpoints are the mechanism that makes caching work. Any route that loses them silently turns a cached request into a full-price one — no error, no signal.

| Path | before | after |
|---|---|---|
| `/anthropic/v1/messages` → `type: anthropic` | ✅ verbatim (`raw_anthropic_body`) | ✅ unchanged |
| `/anthropic/v1/messages` → `type: openai` | ❌ dropped | ✅ preserved |
| `/v1/chat/completions` → `type: anthropic` | ❌ dropped | ✅ preserved |
| `/v1/chat/completions` → `type: openai` | ❌ dropped | ✅ preserved |

## How

**Catch-alls** — `ChatMessage.extra` and `ContentPart::{Text,ImageUrl}.extra`, mirroring `Usage.extra` exactly: flattened, defaulted, `skip_serializing_if` empty. An empty `HashMap` does not allocate, so requests without extras cost nothing and serialize identically.

**Capture** — Anthropic `text`/`image` blocks gain an explicit `cache_control` field, copied into the internal part's `extra`.

**System prompt** — the internal `system` is a flat `String` with nowhere to hold a per-block breakpoint, so it is hoisted to a request-level private key `_anthropic_system_cache_control` (the convention already used by `_anthropic_thinking` / `_anthropic_betas`) and restored as a system **block** when the request goes back out to an Anthropic-format provider.

**Unknown blocks** — the `#[serde(other)]` unit variant discarded the block's data, so the warning could not say *what* it dropped. It is now an untagged catch-all capturing the value, and the log names the block type at `debug`. They are still not forwarded: an Anthropic-only block (`thinking`, `document`) sent to an OpenAI-format upstream would be rejected.

### A second drop site the issue did not name

`parts_to_content` collapsed a message whose parts were all text into a single joined string — discarding every per-part attribute, including a breakpoint that had just survived block translation. It now collapses only when no part carries attributes. This was caught by a new test failing, not by inspection.

## Acceptance criteria

- [x] `cache_control` on a system block or message survives `/anthropic/v1/messages` → `type: openai` — `cache_control_on_message_block_survives_translation`, `cache_control_on_system_block_is_hoisted_to_request_extra`, `cache_control_survives_into_the_openai_body`
- [x] `cache_control` survives `/v1/chat/completions` → `type: anthropic` — `cache_control_reaches_the_anthropic_body`, `system_cache_control_is_restored_as_a_block`
- [x] Unknown blocks are no longer *anonymously* discarded — the type is captured and logged (`unknown_block_is_still_dropped_but_typed`)
- [x] Requests with no extras serialize byte-identically — exact-JSON assertions at three layers
- [x] Round-trip tests in both directions — 14 new tests
- [x] `/anthropic/v1/messages` → `type: anthropic` still takes the verbatim fast path, untouched

## Testing

`cargo test --workspace -- --test-threads=1` — 317 + 107 passing (14 new), 0 failures. Plus `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --release --workspace`.

Serde traps specifically pinned, since both would fail silently:
- the internally-tagged discriminant does **not** leak into `extra` under `flatten`
- the untagged fallback does **not** shadow the tagged variants (`{"type":"text"}` still parses as `Text`)
- the gateway-private `_anthropic_system_cache_control` never reaches an OpenAI upstream (the `_` prefix filter at `openai.rs:307` is what stops it; a rename without the prefix would now fail the test rather than leak)

## Known limitations

**System breakpoints collapse from many to one.** Anthropic permits up to 4 breakpoints; because the internal system prompt is a single `String`, multiple system-block breakpoints reduce to the last one (the widest prefix). Caching stays correct, but partial-prefix granularity is lost on the two translating paths. The verbatim Anthropic→Anthropic path is unaffected. Fixing this properly means restructuring `ChatCompletionRequest.system` into blocks — well beyond this issue.

**Client-supplied message keys now forward upstream.** That is the point of the change, but it is a real behavioural shift: attributes a client attaches to a message or content block now reach the provider instead of being dropped. This matches the trust posture already in place for `ChatCompletionRequest.extra`.

## Out of scope

Bedrock's `cachePoint` wire format (#128 — unblocked by this) and response-side cache counters (#125, merged).
