### PR TITLE
fix(cache): map cache writes to OpenAI's canonical field and log cache tokens on non-streaming requests

### DIFF
--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -270,24 +270,30 @@ non-streaming `usage` object and the streaming `message_delta`:
 }
 ```
 
-On `/v1/chat/completions` cache reads appear in OpenAI's canonical form, and the
-native Anthropic keys are preserved alongside them:
+On `/v1/chat/completions` both counters appear in OpenAI's canonical form under
+`prompt_tokens_details`, and the native Anthropic keys are preserved alongside
+them:
 
 ```json
 "usage": {
   "prompt_tokens": 47,
   "completion_tokens": 2,
   "total_tokens": 49,
-  "prompt_tokens_details": {"cached_tokens": 3968},
+  "prompt_tokens_details": {"cached_tokens": 3968, "cache_write_tokens": 100},
   "cache_read_input_tokens": 3968,
   "cache_creation_input_tokens": 100
 }
 ```
 
 > `prompt_tokens_details.cached_tokens` and `cache_read_input_tokens` describe
-> **the same tokens** in two vocabularies. Read one or the other — never sum
-> them. Cache *creation* has no OpenAI equivalent and is reported only under its
-> native key.
+> **the same tokens** in two vocabularies, as do
+> `prompt_tokens_details.cache_write_tokens` and `cache_creation_input_tokens`.
+> Read one of each pair — never sum them.
+
+The nested pair is what the official OpenAI SDKs expose
+(`PromptTokensDetails.cached_tokens` / `.cache_write_tokens` in both
+`openai-python` and `openai-go`); the top-level Anthropic-native keys are an
+extension those SDKs ignore, so either vocabulary works with a stock client.
 
 Note that `input_tokens` / `prompt_tokens` counts the **non-cached** input for
 that request; cached tokens are reported separately in the fields above.

--- a/docs/user/observability.md
+++ b/docs/user/observability.md
@@ -36,7 +36,10 @@ Every completed request emits a structured log line at `info` level:
 
 `cache_read_tokens` and `cache_write_tokens` are prompt-cache counters. They are
 **omitted entirely** when the provider reported no cache usage, so requests
-against non-caching providers log exactly as before.
+against non-caching providers log exactly as before. Both counters are logged on
+every completed request — streaming and non-streaming, on `request_completed`
+(`/v1/chat/completions`) and `anthropic_request_completed`
+(`/anthropic/v1/messages`) alike.
 
 ---
 

--- a/ferrox/src/handlers/anthropic_messages.rs
+++ b/ferrox/src/handlers/anthropic_messages.rs
@@ -441,6 +441,11 @@ pub async fn anthropic_messages(
                     .with_label_values(&[provider_name.as_str(), model_alias.as_str(), "200"])
                     .observe(latency);
 
+                let (cache_read, cache_write) = resp
+                    .usage
+                    .as_ref()
+                    .map(crate::types::cache_tokens)
+                    .unwrap_or((0, 0));
                 tracing::info!(
                     request_id = %ctx.request_id,
                     key_name   = %ctx.key_name,
@@ -450,6 +455,12 @@ pub async fn anthropic_messages(
                     streaming  = false,
                     status     = 200,
                     latency_ms = (latency * 1000.0) as u64,
+                    prompt_tokens = resp.usage.as_ref().map(|u| u.prompt_tokens).unwrap_or(0),
+                    completion_tokens = resp.usage.as_ref().map(|u| u.completion_tokens).unwrap_or(0),
+                    // `Option` fields are omitted entirely when `None`, so
+                    // non-caching requests log exactly as they did before.
+                    cache_read_tokens = (cache_read > 0).then_some(cache_read),
+                    cache_write_tokens = (cache_write > 0).then_some(cache_write),
                     "anthropic_request_completed"
                 );
 

--- a/ferrox/src/handlers/chat.rs
+++ b/ferrox/src/handlers/chat.rs
@@ -305,6 +305,11 @@ pub async fn chat_completions(
                     .with_label_values(&[provider_name.as_str(), req.model.as_str(), "200"])
                     .observe(latency);
 
+                let (cache_read, cache_write) = resp
+                    .usage
+                    .as_ref()
+                    .map(crate::types::cache_tokens)
+                    .unwrap_or((0, 0));
                 tracing::info!(
                     request_id = %ctx.request_id,
                     key_name = %ctx.key_name,
@@ -316,6 +321,10 @@ pub async fn chat_completions(
                     latency_ms = (latency * 1000.0) as u64,
                     prompt_tokens = resp.usage.as_ref().map(|u| u.prompt_tokens).unwrap_or(0),
                     completion_tokens = resp.usage.as_ref().map(|u| u.completion_tokens).unwrap_or(0),
+                    // `Option` fields are omitted entirely when `None`, so
+                    // non-caching requests log exactly as they did before.
+                    cache_read_tokens = (cache_read > 0).then_some(cache_read),
+                    cache_write_tokens = (cache_write > 0).then_some(cache_write),
                     "request_completed"
                 );
 

--- a/ferrox/src/types.rs
+++ b/ferrox/src/types.rs
@@ -263,15 +263,21 @@ pub const CACHE_READ_INPUT_TOKENS: &str = "cache_read_input_tokens";
 pub const PROMPT_TOKENS_DETAILS: &str = "prompt_tokens_details";
 /// OpenAI-canonical key for cache reads, nested under [`PROMPT_TOKENS_DETAILS`].
 pub const CACHED_TOKENS: &str = "cached_tokens";
+/// OpenAI-canonical key for cache writes, nested under [`PROMPT_TOKENS_DETAILS`].
+///
+/// Declared by the official SDKs as "the unadjusted number of prompt tokens
+/// written to cache" (`openai-python` `PromptTokensDetails.cache_write_tokens`,
+/// `openai-go` `CompletionUsagePromptTokensDetails.CacheWriteTokens`).
+pub const CACHE_WRITE_TOKENS: &str = "cache_write_tokens";
 
 /// Build the [`Usage::extra`] entries for a pair of prompt-cache counters.
 ///
-/// Cache **reads** are represented twice on purpose: once under the
-/// Anthropic-native `cache_read_input_tokens` key and once as OpenAI's
-/// `prompt_tokens_details.cached_tokens`, so both API surfaces report them
-/// without a second translation step. **They are the same tokens — a consumer
-/// must read exactly one of the two and never sum them.** Cache *creation* has
-/// no OpenAI equivalent and is emitted only under its native key.
+/// Each counter is represented twice on purpose: once under its Anthropic-native
+/// key (`cache_read_input_tokens` / `cache_creation_input_tokens`) and once
+/// under OpenAI's `prompt_tokens_details` (`cached_tokens` / `cache_write_tokens`),
+/// so both API surfaces report them without a second translation step. **Each
+/// pair is the same tokens — a consumer must read exactly one of the two and
+/// never sum them.**
 ///
 /// Returns an empty map when neither counter is present, which keeps the
 /// no-cache path allocation-free (`HashMap::new` does not allocate) and makes
@@ -281,14 +287,19 @@ pub fn cache_usage_extra(
     read: Option<u32>,
 ) -> HashMap<String, serde_json::Value> {
     let mut extra = HashMap::new();
+    let mut details = serde_json::Map::new();
     if let Some(creation) = creation {
         extra.insert(CACHE_CREATION_INPUT_TOKENS.to_string(), creation.into());
+        details.insert(CACHE_WRITE_TOKENS.to_string(), creation.into());
     }
     if let Some(read) = read {
         extra.insert(CACHE_READ_INPUT_TOKENS.to_string(), read.into());
+        details.insert(CACHED_TOKENS.to_string(), read.into());
+    }
+    if !details.is_empty() {
         extra.insert(
             PROMPT_TOKENS_DETAILS.to_string(),
-            serde_json::json!({ CACHED_TOKENS: read }),
+            serde_json::Value::Object(details),
         );
     }
     extra
@@ -307,23 +318,28 @@ pub fn cache_tokens(usage: &Usage) -> (u32, u32) {
 
 /// Recover `(cache_creation, cache_read)` from [`Usage::extra`].
 ///
-/// The Anthropic-native keys win; `prompt_tokens_details.cached_tokens` is the
-/// fallback for reads so usage that originated from an OpenAI-format upstream
-/// still round-trips onto the Anthropic surface.
+/// The Anthropic-native keys win; the `prompt_tokens_details` counterparts
+/// (`cached_tokens` for reads, `cache_write_tokens` for writes) are the fallback,
+/// so usage that originated from an OpenAI-format upstream still round-trips
+/// onto the Anthropic surface.
 pub fn cache_tokens_from_extra(
     extra: &HashMap<String, serde_json::Value>,
 ) -> (Option<u32>, Option<u32>) {
     let as_u32 = |v: &serde_json::Value| v.as_u64().map(|t| t as u32);
-    let creation = extra.get(CACHE_CREATION_INPUT_TOKENS).and_then(as_u32);
+    let detail = |key: &str| {
+        extra
+            .get(PROMPT_TOKENS_DETAILS)
+            .and_then(|d| d.get(key))
+            .and_then(as_u32)
+    };
+    let creation = extra
+        .get(CACHE_CREATION_INPUT_TOKENS)
+        .and_then(as_u32)
+        .or_else(|| detail(CACHE_WRITE_TOKENS));
     let read = extra
         .get(CACHE_READ_INPUT_TOKENS)
         .and_then(as_u32)
-        .or_else(|| {
-            extra
-                .get(PROMPT_TOKENS_DETAILS)
-                .and_then(|d| d.get(CACHED_TOKENS))
-                .and_then(as_u32)
-        });
+        .or_else(|| detail(CACHED_TOKENS));
     (creation, read)
 }
 
@@ -574,5 +590,56 @@ mod tests {
             serde_json::json!({"cached_tokens": 512}),
         )]));
         assert_eq!(cache_tokens(&usage), (512, 0));
+    }
+
+    #[test]
+    fn cache_tokens_reads_openai_cache_write_tokens_fallback() {
+        let usage = usage_with(HashMap::from([(
+            "prompt_tokens_details".to_string(),
+            serde_json::json!({"cache_write_tokens": 256}),
+        )]));
+        assert_eq!(cache_tokens(&usage), (0, 256));
+    }
+
+    /// Both counters must land under `prompt_tokens_details` as well as their
+    /// Anthropic-native keys — the official OpenAI SDKs read the nested pair
+    /// (`PromptTokensDetails.cached_tokens` / `.cache_write_tokens`) and ignore
+    /// anything at the top level of `usage`.
+    #[test]
+    fn cache_usage_extra_emits_both_openai_details() {
+        let extra = cache_usage_extra(Some(100), Some(3968));
+        assert_eq!(extra["cache_creation_input_tokens"], 100);
+        assert_eq!(extra["cache_read_input_tokens"], 3968);
+        assert_eq!(extra["prompt_tokens_details"]["cache_write_tokens"], 100);
+        assert_eq!(extra["prompt_tokens_details"]["cached_tokens"], 3968);
+    }
+
+    /// A write with no read still has to produce the OpenAI container, or a
+    /// cache-creating request looks cacheless to an OpenAI SDK consumer.
+    #[test]
+    fn cache_usage_extra_write_only_still_emits_details() {
+        let extra = cache_usage_extra(Some(100), None);
+        assert_eq!(extra["prompt_tokens_details"]["cache_write_tokens"], 100);
+        assert!(extra["prompt_tokens_details"]
+            .get("cached_tokens")
+            .is_none());
+        assert!(!extra.contains_key("cache_read_input_tokens"));
+    }
+
+    #[test]
+    fn cache_usage_extra_read_only_omits_write_key() {
+        let extra = cache_usage_extra(None, Some(3968));
+        assert_eq!(extra["prompt_tokens_details"]["cached_tokens"], 3968);
+        assert!(extra["prompt_tokens_details"]
+            .get("cache_write_tokens")
+            .is_none());
+        assert!(!extra.contains_key("cache_creation_input_tokens"));
+    }
+
+    /// The no-cache path must stay byte-identical to a response from a build
+    /// without cache support — no empty `prompt_tokens_details` container.
+    #[test]
+    fn cache_usage_extra_empty_when_neither_counter_present() {
+        assert!(cache_usage_extra(None, None).is_empty());
     }
 }


### PR DESCRIPTION
Validated the merged prompt-cache work (#130, #131, #132, #134, #135) against the **official SDKs** — `openai-python 2.49.0`, `openai-go v3.46.0`, `anthropic-sdk-python 0.120.0`, `anthropic-sdk-go v1.61.0` — by running each SDK's own typed client against a gateway built from `main` and reading the usage models a real consumer reads, not the raw JSON. Two gaps came out of it.

## 1. Cache writes were invisible to OpenAI SDK consumers

`cache_usage_extra` emitted cache creation only under the Anthropic-native `cache_creation_input_tokens`, documented as *"cache creation has no OpenAI equivalent"*. That is no longer true — both official SDKs now declare `prompt_tokens_details.cache_write_tokens`:

- `openai-python` — `PromptTokensDetails.cache_write_tokens`, *"The unadjusted number of prompt tokens written to cache"* (`src/openai/types/completion_usage.py:40`)
- `openai-go` — `CompletionUsagePromptTokensDetails.CacheWriteTokens` (`completion.go:238`)

Measured against the gateway before this change:

```
PromptTokensDetails.CachedTokens     = 6592 (present=true)
PromptTokensDetails.CacheWriteTokens = 0    (present=false)
UNDECLARED extra fields on usage     = [cache_read_input_tokens]
```

So a stock OpenAI client saw reads but never writes, for any provider that does report them (Anthropic proper, Bedrock `cachePoint` from #135). The Anthropic-native key we did send landed in the SDKs' undeclared-extras bucket (`model_extra` / `JSON.ExtraFields`) and was ignored.

Both counters now go under `prompt_tokens_details` alongside their native keys, and `cache_tokens_from_extra` reads `cache_write_tokens` as the fallback for creation — mirroring what it already did with `cached_tokens` for reads, so usage from an OpenAI-format upstream round-trips onto the Anthropic surface. The container is still omitted entirely when neither counter is present, so responses from non-caching providers stay byte-identical.

## 2. Non-streaming requests logged no cache counters

#132 updated only the streaming branches. `request_completed` (`chat.rs`) carried prompt/completion but no cache fields, and `anthropic_request_completed` carried **no token fields at all**. Bodies and metrics were already correct on those paths — only the log line was blind, which defeats the stated goal of confirming caching from the logs for any non-streaming caller. `docs/user/observability.md` already documented the fields on a `"streaming": false` example, so the docs were right and the code was the gap.

Both sites now log the same `Option`-typed pair the streaming branches use, so non-caching requests log exactly as before.

## Verification

Live against Z.AI through the gateway — cold prefix, then the warm follow-up:

```
# /v1/chat/completions
call 1: prompt=8814 details={'cached_tokens': 0}
call 2: prompt=46   details={'cached_tokens': 8768}
request_completed ... prompt_tokens=8814 completion_tokens=2
request_completed ... prompt_tokens=46 completion_tokens=2 cache_read_tokens=8768

# /anthropic/v1/messages
usage: {'input_tokens': 9134, 'output_tokens': 2, 'cache_read_input_tokens': 0}
usage: {'input_tokens': 46,   'output_tokens': 2, 'cache_read_input_tokens': 9088}
anthropic_request_completed ... prompt_tokens=9134 completion_tokens=2
anthropic_request_completed ... prompt_tokens=46 completion_tokens=2 cache_read_tokens=9088
```

Five new unit tests cover the mapping in both directions, including write-only and read-only usage and the empty case. `cargo test -p ferrox` — 330 passed; clippy clean.

**Not exercised live:** the cache *write* path. Z.AI never reports `cache_creation_input_tokens`, confirmed with a provably cold nonce prefix (`input=9034, write=None`, follow-up `read=9024`), and Moonshot is currently quota-exhausted. The write mapping is covered by unit tests only.

## Also confirmed compliant (no change needed)

The Anthropic surface passes both SDKs cleanly on non-streaming *and* streaming. The streaming case was the real risk, since Ferrox sends `input_tokens: 0` in `message_start` and the true values in `message_delta` — both SDKs' accumulators overwrite from the delta when the field is present (`_messages.py:511-516`, `messageutil.go:35-42`), so `get_final_message()` / `Accumulate` land on the right numbers. Ferrox also correctly omits `cache_creation_input_tokens` rather than sending a fake `0`; the Go SDK reports `present on wire = false`.
