### PR TITLE
fix(auth): compare virtual keys in constant time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,6 +1429,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sqlx",
+ "subtle",
  "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",

--- a/ferrox/Cargo.toml
+++ b/ferrox/Cargo.toml
@@ -45,6 +45,9 @@ async-trait = "0.1"
 futures = "0.3"
 bytes = "1"
 
+# Security
+subtle = "2"  # constant-time secret comparison (see auth.rs, ferrox-cp/middleware/admin_auth.rs)
+
 # Error handling
 thiserror = "1"
 anyhow = "1"

--- a/ferrox/src/auth.rs
+++ b/ferrox/src/auth.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use serde::Deserialize;
+use subtle::ConstantTimeEq;
 use uuid::Uuid;
 
 use crate::config::RateLimitConfig;
@@ -117,11 +118,17 @@ pub async fn auth_middleware(
 // ── Static key path ───────────────────────────────────────────────────────────
 
 async fn validate_static_key(token: &str, state: &AppState) -> Result<AuthOutcome, ProxyError> {
+    // Constant-time comparison: a plain `==` on strings returns as soon as two
+    // bytes differ, which makes response time depend on how many leading bytes
+    // of a guessed key are correct — a byte-at-a-time credential oracle.
+    // `ct_eq` also handles unequal lengths without branching on content, so no
+    // padding is needed. Same idiom as the control plane's admin-key check in
+    // `ferrox-cp/src/middleware/admin_auth.rs`.
     let key_config = state
         .config
         .virtual_keys
         .iter()
-        .find(|k| k.key == token)
+        .find(|k| bool::from(k.key.as_bytes().ct_eq(token.as_bytes())))
         .ok_or_else(|| ProxyError::Unauthorized("Invalid API key".to_string()))?;
 
     if let Some(rl) = &key_config.rate_limit {
@@ -515,6 +522,62 @@ mod tests {
             let outcome = validate_static_key("sk-real", &state).await.unwrap();
             assert_eq!(outcome.key_name, "test-key");
             assert_eq!(outcome.allowed_models, vec!["claude-sonnet"]);
+        }
+
+        // ── Constant-time comparison (#144) ──────────────────────────────────
+        //
+        // Timing itself is not unit-testable; these pin the *behaviour* the
+        // constant-time comparison must preserve. The equal-length and shared-
+        // prefix cases are the ones a careless "fix" gets wrong.
+
+        #[tokio::test]
+        async fn wrong_key_of_equal_length_is_rejected() {
+            let state = build_state(config_with_key("sk-abcdefgh", None));
+            let err = validate_static_key("sk-abcdefgi", &state)
+                .await
+                .unwrap_err();
+            assert!(matches!(err, ProxyError::Unauthorized(_)));
+        }
+
+        #[tokio::test]
+        async fn wrong_key_of_different_length_is_rejected() {
+            let state = build_state(config_with_key("sk-abcdefgh", None));
+            for candidate in ["sk-abcdefg", "sk-abcdefghi", ""] {
+                let err = validate_static_key(candidate, &state).await.unwrap_err();
+                assert!(
+                    matches!(err, ProxyError::Unauthorized(_)),
+                    "candidate {candidate:?} should not authenticate"
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn key_sharing_a_long_prefix_is_rejected() {
+            // The exact shape a byte-at-a-time timing attack walks through:
+            // every byte correct except the last.
+            let state = build_state(config_with_key("sk-super-secret-value", None));
+            let err = validate_static_key("sk-super-secret-valuX", &state)
+                .await
+                .unwrap_err();
+            assert!(matches!(err, ProxyError::Unauthorized(_)));
+        }
+
+        #[tokio::test]
+        async fn correct_key_still_authenticates_among_several() {
+            // Guards the `.find()` rewrite: the predicate must still match the
+            // right entry when more than one key is configured.
+            let mut config = config_with_key("sk-first", None);
+            config.virtual_keys.push(VirtualKeyConfig {
+                key: "sk-second".to_string(),
+                name: "second-key".to_string(),
+                description: None,
+                allowed_models: vec![],
+                rate_limit: None,
+            });
+            let state = build_state(config);
+
+            let outcome = validate_static_key("sk-second", &state).await.unwrap();
+            assert_eq!(outcome.key_name, "second-key");
         }
 
         #[tokio::test]


### PR DESCRIPTION
Closes #144

## What

`ferrox/src/auth.rs` matched the inbound bearer token against configured virtual keys with `==`, which short-circuits on the first differing byte. Swapped for `subtle::ConstantTimeEq`.

## Why

Response time correlated with how many leading bytes of a guessed key were correct — a byte-at-a-time credential oracle against the only thing gating the upstream provider keys. The signal is small over a WAN but much larger over loopback (which #142 explicitly enabled by extracting `ferrox-providers` for desktop use) and for a co-tenant on the same host.

The strongest argument is internal inconsistency: **the control plane already gets this right.** `ferrox-cp/src/middleware/admin_auth.rs:9,40` uses `ConstantTimeEq` for exactly this comparison. The data-plane check should not be weaker than the admin API in front of it. This PR makes the two read the same way.

## How

```rust
.find(|k| bool::from(k.key.as_bytes().ct_eq(token.as_bytes())))
```

`ct_eq` returns 0 for unequal lengths without branching on content, so no manual padding is needed. `subtle = "2"` was already a workspace dependency via `ferrox-cp`, so **nothing new enters the lockfile** and `cargo audit` is unchanged.

## Verification

| Check | Result |
|---|---|
| `cargo test --workspace -- --test-threads=1` | 441 passed, 0 failed |
| New regression tests | 4, all passing |
| `grep -rnE "\.key ==\|== token" ferrox/src` | no matches — this was the only one |
| `cargo clippy --workspace -- -D warnings` / `cargo fmt --all --check` | clean |

Timing is not unit-testable, so the tests pin the *behaviour* the fix must preserve — the cases a careless fix breaks: a wrong key of **equal length**, wrong keys of **different** lengths (including empty), a key sharing **all but the final byte** (the exact shape a timing attack walks through), and a correct key still matching when **several keys are configured**, which guards the rewritten predicate.

## Out of scope

`.find()` still stops at the first match, so the number of comparisons leaks a little about *which* key matched. That signal is bounded by the small, non-secret number of configured keys, and eliminating it means a full scan on every authenticated request — a hot-path cost this project treats as first-order. Decided against during refinement; a separate issue if ever wanted.