### PR TITLE
fix(config): remove the dead `providers[].retry` field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,6 +1491,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -107,8 +107,6 @@ providers:
     # Optional per-provider overrides:
     timeouts:
       ttfb_secs: 90
-    retry:
-      max_attempts: 2
     circuit_breaker:
       failure_threshold: 3
 ```
@@ -133,7 +131,6 @@ static-keys / profile / AssumeRole auth modes.
 | `base_url` | no | Override the default endpoint. Must include the API version prefix (e.g. `https://api.openai.com/v1`). The adapter appends only `/chat/completions`. |
 | `aws` | no | AWS config (Bedrock only): `region`, optional `endpoint_url`, and `auth` (static keys / `profile` / `assume_role`). |
 | `timeouts` | no | Per-provider timeout overrides |
-| `retry` | no | Per-provider retry overrides |
 | `circuit_breaker` | no | Per-provider circuit breaker overrides |
 
 ---

--- a/docs/user/providers.md
+++ b/docs/user/providers.md
@@ -257,7 +257,7 @@ This distributes requests evenly across two API keys, effectively doubling the r
 
 ## Per-provider overrides
 
-Any provider can override the global `defaults` for timeouts, retries, and circuit breaker settings:
+Any provider can override the global `defaults` for timeouts and circuit breaker settings:
 
 ```yaml
 providers:
@@ -266,8 +266,6 @@ providers:
     api_key: "${ANTHROPIC_API_KEY}"
     timeouts:
       ttfb_secs: 120    # extended for reasoning models
-    retry:
-      max_attempts: 2   # fail faster for primary; let fallback handle it
     circuit_breaker:
-      failure_threshold: 3
+      failure_threshold: 3   # trip sooner for primary; let fallback take over
 ```

--- a/ferrox-providers/Cargo.toml
+++ b/ferrox-providers/Cargo.toml
@@ -69,6 +69,7 @@ aws-smithy-types = { version = "1", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde_yaml = "0.9"  # config deserialization tests only
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/ferrox-providers/README.md
+++ b/ferrox-providers/README.md
@@ -35,7 +35,6 @@ let providers = vec![ProviderConfig {
     base_url: None,
     aws: None,
     timeouts: None,
-    retry: None,
     circuit_breaker: None,
 }];
 
@@ -77,9 +76,10 @@ Carried over from the extraction and worth knowing before depending on the API:
 - **`ProxyError` still carries gateway-flavoured variants** (`RateLimited`,
   `BudgetExceeded`, `CircuitOpen`) that this crate never constructs. Splitting
   the enum would ripple through every Ferrox handler, so it was left alone.
-- **`ProviderConfig` and `DefaultsConfig` carry `retry` / `circuit_breaker`**,
-  which the adapters never read. They are part of the same deserialized YAML
-  object; dropping them would silently discard those keys on round-trip.
+- **`DefaultsConfig` carries `retry` / `circuit_breaker`**, which the adapters
+  never read. They are part of the same deserialized YAML object; dropping them
+  would silently discard that gateway policy on round-trip. (`ProviderConfig`
+  no longer carries a dead `retry` — removed in #145.)
 - **`parse_sse_stream` takes a `reqwest::Response`**, so `reqwest`'s major
   version is part of the public API surface.
 

--- a/ferrox-providers/src/config.rs
+++ b/ferrox-providers/src/config.rs
@@ -6,9 +6,9 @@
 //! depending on `ferrox` itself.
 //!
 //! [`RetryConfig`] and [`CircuitBreakerConfig`] are never read by this crate.
-//! They are carried because [`ProviderConfig`] and [`DefaultsConfig`] are
-//! deserialized from a single YAML object that also holds those per-provider
-//! overrides, and splitting the struct would silently drop them on round-trip.
+//! They are carried because [`DefaultsConfig`] is deserialized from a single
+//! YAML object that also holds that gateway policy, and splitting the struct
+//! would silently drop it on round-trip.
 
 use serde::{Deserialize, Serialize};
 
@@ -153,7 +153,6 @@ pub struct ProviderConfig {
     /// provider; ignored by every other provider type.
     pub aws: Option<AwsConfig>,
     pub timeouts: Option<TimeoutsConfig>,
-    pub retry: Option<RetryConfig>,
     pub circuit_breaker: Option<CircuitBreakerConfig>,
 }
 
@@ -208,4 +207,48 @@ pub struct AwsAssumeRoleConfig {
     pub external_id: Option<String>,
     /// Session duration in seconds (STS default is 3600 when omitted).
     pub duration_secs: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `providers[].retry` was a dead field, removed in #145. Configs written
+    /// against older versions still carry it, so deserialization must keep
+    /// ignoring the key rather than failing — i.e. `ProviderConfig` must never
+    /// gain `#[serde(deny_unknown_fields)]`.
+    #[test]
+    fn provider_config_still_loads_when_a_legacy_retry_key_is_present() {
+        let yaml = r#"
+name: anthropic-primary
+type: anthropic
+api_key: sk-test
+retry:
+  max_attempts: 2
+circuit_breaker:
+  failure_threshold: 3
+"#;
+        let cfg: ProviderConfig =
+            serde_yaml::from_str(yaml).expect("legacy retry key must not break parsing");
+
+        assert_eq!(cfg.name, "anthropic-primary");
+        assert_eq!(cfg.provider_type, ProviderType::Anthropic);
+        assert_eq!(cfg.api_key.as_deref(), Some("sk-test"));
+        // The still-supported sibling override must survive alongside it.
+        assert_eq!(
+            cfg.circuit_breaker
+                .expect("circuit_breaker")
+                .failure_threshold,
+            3
+        );
+    }
+
+    /// `defaults.retry` is real and read by the gateway — guard against it
+    /// being removed along with the per-provider one.
+    #[test]
+    fn defaults_config_still_parses_retry() {
+        let yaml = "retry:\n  max_attempts: 7\n";
+        let cfg: DefaultsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.retry.max_attempts, 7);
+    }
 }

--- a/ferrox-providers/src/providers/gemini.rs
+++ b/ferrox-providers/src/providers/gemini.rs
@@ -779,7 +779,6 @@ mod tests {
                 base_url: None,
                 aws: None,
                 timeouts: None,
-                retry: None,
                 circuit_breaker: None,
             },
             &DefaultsConfig::default(),

--- a/ferrox-providers/src/providers/openai.rs
+++ b/ferrox-providers/src/providers/openai.rs
@@ -450,7 +450,6 @@ mod tests {
             base_url: base_url.map(str::to_string),
             aws: None,
             timeouts: None,
-            retry: None,
             circuit_breaker: None,
         }
     }

--- a/ferrox/config.schema.json
+++ b/ferrox/config.schema.json
@@ -162,7 +162,6 @@
         },
         "aws": { "$ref": "#/definitions/AwsConfig" },
         "timeouts": { "$ref": "#/definitions/TimeoutsConfig" },
-        "retry": { "$ref": "#/definitions/RetryConfig" },
         "circuit_breaker": { "$ref": "#/definitions/CircuitBreakerConfig" }
       }
     },

--- a/ferrox/config/config.yaml
+++ b/ferrox/config/config.yaml
@@ -69,8 +69,6 @@ providers:
       connect_secs: 10
       ttfb_secs: 60
       idle_secs: 30
-    retry:
-      max_attempts: 2
     circuit_breaker:
       failure_threshold: 3
 

--- a/ferrox/src/config.rs
+++ b/ferrox/src/config.rs
@@ -613,7 +613,6 @@ mod tests {
                 base_url: None,
                 aws: None,
                 timeouts: None,
-                retry: None,
                 circuit_breaker: None,
             }],
             models: vec![ModelConfig {
@@ -653,7 +652,6 @@ mod tests {
             base_url: None,
             aws: None,
             timeouts: None,
-            retry: None,
             circuit_breaker: None,
         });
         let err = validate(&config).unwrap_err().to_string();

--- a/ferrox/src/router.rs
+++ b/ferrox/src/router.rs
@@ -105,7 +105,6 @@ mod tests {
                 base_url: None,
                 aws: None,
                 timeouts: None,
-                retry: None,
                 circuit_breaker: None,
             }],
             models: aliases
@@ -181,7 +180,6 @@ mod tests {
             base_url: None,
             aws: None,
             timeouts: None,
-            retry: None,
             circuit_breaker: None,
         });
 


### PR DESCRIPTION
Closes #145

## What

`ProviderConfig.retry` was deserialized and then discarded. Removed it, along with everything that advertised it.

## Why

Nothing in the workspace read it — only `defaults.retry` is consumed (`handlers/chat.rs:67`, `handlers/anthropic_messages.rs:145`).

That makes it worse than ordinary dead code, because the shipped example config **presented it as working**:

```yaml
  - name: anthropic-primary
    retry:
      max_attempts: 2        # ← silently did nothing
    circuit_breaker:
      failure_threshold: 3   # ← this one works (lb/mod.rs:115)
```

Two adjacent, symmetrical-looking keys with different behaviour, plus a docs table row calling it "Per-provider retry overrides". Someone tuning a flaky provider would set it, get the default 3 attempts anyway, and have nothing to diagnose. Silent config no-ops are expensive precisely because the config *looks* applied.

Secondary: since #142 `ProviderConfig` is part of `ferrox-providers`' published API, so this was a dead field on a struct other applications now consume.

## How

Deletion across five files, no logic change:

| File | Change |
|---|---|
| `ferrox-providers/src/config.rs` | field removed; module doc narrowed |
| `ferrox/config.schema.json` | one line — `ProviderConfig.retry` only |
| `ferrox/config/config.yaml` | the two-line block |
| `docs/user/configuration.md` | example block + table row |
| `ferrox-providers/README.md` | rough-edges bullet, **and the usage example, which would no longer have compiled** |

`RetryConfig` itself stays — `DefaultsConfig.retry` is real and read.

## Verification

| Check | Result |
|---|---|
| `cargo test --workspace -- --test-threads=1` | 443 passed, 0 failed |
| New tests | 2 — legacy-key tolerance, and `defaults.retry` still parsing |
| Both shipped configs load in Rust | ✅ |
| Both validate against the tightened schema | ✅ (checked locally before pushing) |
| `clippy -D warnings` / `fmt --check` | clean |

The legacy-key test is the important one: it pins that a config still carrying `providers[].retry` keeps deserializing, so this removal can never silently become a hard parse failure. It fails if anyone adds `#[serde(deny_unknown_fields)]` to `ProviderConfig`.

## ⚠️ One intended user-visible break — for the release notes

`definitions/ProviderConfig` sets `additionalProperties: false`. A user config that still sets `providers[].retry` will now **fail schema validation**. Rust-side loading is unaffected (serde ignores the unknown key), so the gateway still starts.

This is deliberate: a validation error naming the removed key is far better than the silent no-op it replaces. Flagging it rather than letting it surprise someone.